### PR TITLE
Add explicit infinite loops to interactive test programs

### DIFF
--- a/test/interactive/picolibrary/asynchronous_serial/unbuffered_output_stream/hello_world/microchip/megaavr/main.cc
+++ b/test/interactive/picolibrary/asynchronous_serial/unbuffered_output_stream/hello_world/microchip/megaavr/main.cc
@@ -50,4 +50,6 @@ int main()
         TRANSMITTER_USART::instance(),
         { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
           .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } } );
+
+    for ( ;; ) {}
 }

--- a/test/interactive/picolibrary/microchip/megaavr/asynchronous_serial/transmitter_8_n_1/hello_world/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr/asynchronous_serial/transmitter_8_n_1/hello_world/main.cc
@@ -49,4 +49,6 @@ int main()
         TRANSMITTER_USART::instance(),
         { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
           .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } } );
+
+    for ( ;; ) {}
 }

--- a/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/main.cc
@@ -47,4 +47,6 @@ int main()
     toggle( Open_Drain_IO_Pin{ PIN_PORT::instance(), PIN_MASK }, []() {
         avrlibcpp::delay_ms( 500 );
     } );
+
+    for ( ;; ) {}
 }

--- a/test/interactive/picolibrary/microchip/megaavr/gpio/push_pull_io_pin/toggle/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr/gpio/push_pull_io_pin/toggle/main.cc
@@ -47,4 +47,6 @@ int main()
     toggle( Push_Pull_IO_Pin{ PIN_PORT::instance(), PIN_MASK }, []() {
         avrlibcpp::delay_ms( 500 );
     } );
+
+    for ( ;; ) {}
 }

--- a/test/interactive/picolibrary/microchip/megaavr/spi/controller/spi/echo/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr/spi/controller/spi/echo/main.cc
@@ -55,20 +55,24 @@ using Controller = ::picolibrary::Microchip::megaAVR::SPI::Controller<SPI>;
  */
 int main()
 {
-    auto ss = Push_Pull_IO_Pin{ SS_PORT::instance(), SS_MASK };
+    {
+        auto ss = Push_Pull_IO_Pin{ SS_PORT::instance(), SS_MASK };
 
-    static_cast<void>( ss.initialize() );
+        static_cast<void>( ss.initialize() );
 
-    echo<Unbuffered_Output_Stream>(
-        Transmitter_8_N_1{ TRANSMITTER_USART::instance(),
-                           { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
-                             .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } },
-        Controller{ Push_Pull_IO_Pin{ SCK_PORT::instance(), SCK_MASK },
-                    Push_Pull_IO_Pin{ MOSI_PORT::instance(), MOSI_MASK },
-                    CONTROLLER_SPI::instance() },
-        { SPI::Clock_Rate::CONTROLLER_CLOCK_RATE,
-          SPI::Clock_Polarity::CONTROLLER_CLOCK_POLARITY,
-          SPI::Clock_Phase::CONTROLLER_CLOCK_PHASE,
-          SPI::Bit_Order::CONTROLLER_BIT_ORDER },
-        []() { avrlibcpp::delay_ms( 100 ); } );
+        echo<Unbuffered_Output_Stream>(
+            Transmitter_8_N_1{ TRANSMITTER_USART::instance(),
+                               { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+                                 .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } },
+            Controller{ Push_Pull_IO_Pin{ SCK_PORT::instance(), SCK_MASK },
+                        Push_Pull_IO_Pin{ MOSI_PORT::instance(), MOSI_MASK },
+                        CONTROLLER_SPI::instance() },
+            { SPI::Clock_Rate::CONTROLLER_CLOCK_RATE,
+              SPI::Clock_Polarity::CONTROLLER_CLOCK_POLARITY,
+              SPI::Clock_Phase::CONTROLLER_CLOCK_PHASE,
+              SPI::Bit_Order::CONTROLLER_BIT_ORDER },
+            []() { avrlibcpp::delay_ms( 100 ); } );
+    }
+
+    for ( ;; ) {}
 }


### PR DESCRIPTION
Resolves #124.

Embedded programs run forever. Interactive test programs previously
relied on avr-gcc's non-obvious return from main() behavior (disable
interrupts and enter an infinite loop) instead of using explicit
infinite loops.This could trip up those who are not familiar with
avr-gcc's behavior.