### PR TITLE
Use designated initializers when initializing structs

### DIFF
--- a/test/interactive/picolibrary/microchip/megaavr/spi/controller/spi/echo/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr/spi/controller/spi/echo/main.cc
@@ -62,10 +62,10 @@ int main()
         Controller{ Push_Pull_IO_Pin{ SCK_PORT::instance(), SCK_MASK },
                     Push_Pull_IO_Pin{ MOSI_PORT::instance(), MOSI_MASK },
                     CONTROLLER_SPI::instance() },
-        { SPI::Clock_Rate::CONTROLLER_CLOCK_RATE,
-          SPI::Clock_Polarity::CONTROLLER_CLOCK_POLARITY,
-          SPI::Clock_Phase::CONTROLLER_CLOCK_PHASE,
-          SPI::Bit_Order::CONTROLLER_BIT_ORDER },
+        { .clock_rate     = SPI::Clock_Rate::CONTROLLER_CLOCK_RATE,
+          .clock_polarity = SPI::Clock_Polarity::CONTROLLER_CLOCK_POLARITY,
+          .clock_phase    = SPI::Clock_Phase::CONTROLLER_CLOCK_PHASE,
+          .bit_order      = SPI::Bit_Order::CONTROLLER_BIT_ORDER },
         []() { avrlibcpp::delay_ms( 100 ); } );
 
     for ( ;; ) {}

--- a/test/interactive/picolibrary/microchip/megaavr/spi/controller/usart/echo/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr/spi/controller/usart/echo/main.cc
@@ -59,10 +59,10 @@ int main()
                            { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
                              .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } },
         Controller{ Push_Pull_IO_Pin{ XCK_PORT::instance(), XCK_MASK }, CONTROLLER_USART::instance() },
-        { CONTROLLER_SCALING_FACTOR,
-          USART::Clock_Polarity::CONTROLLER_CLOCK_POLARITY,
-          USART::Clock_Phase::CONTROLLER_CLOCK_PHASE,
-          USART::Bit_Order::CONTROLLER_BIT_ORDER },
+        { .scaling_factor = CONTROLLER_SCALING_FACTOR,
+          .clock_polarity = USART::Clock_Polarity::CONTROLLER_CLOCK_POLARITY,
+          .clock_phase    = USART::Clock_Phase::CONTROLLER_CLOCK_PHASE,
+          .bit_order      = USART::Bit_Order::CONTROLLER_BIT_ORDER },
         []() { avrlibcpp::delay_ms( 100 ); } );
 
     for ( ;; ) {}


### PR DESCRIPTION
Resolves #144.