### PR TITLE
Update submodule URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -39,4 +39,4 @@
 # lizard
 [submodule "lizard"]
 	path = lizard
-	url = ../terryyin-lizard
+	url = ../lizard


### PR DESCRIPTION
Resolves #158.

The lizard submodule URL pointed to a "mirror" (terryyin-lizard) instead
of a fork (lizard).