### PR TITLE
Remove submodule checkout from shellcheck static analysis CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,6 @@ jobs:
         runs-on: ubuntu-20.04
         steps:
             - uses: actions/checkout@v2
-              with:
-                  submodules: recursive
             - name: Analyze
               shell: bash
               run: ./ci/analyze --analyzer shellcheck


### PR DESCRIPTION
Resolves #232 (Remove submodule checkout from shellcheck static analysis
CI job).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
