### PR TITLE
Fix multiplexed signals lookup function parameter naming

### DIFF
--- a/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega2560/spi.h
+++ b/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega2560/spi.h
@@ -38,13 +38,13 @@ namespace picolibrary::Microchip::megaAVR::Multiplexed_Signals::ATmega2560 {
  *            compiler flag to `atmega2560` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::ds_port().
  *
- * \param[in] usart The SPI peripheral whose DS pin port is to be looked up.
+ * \param[in] spi The SPI peripheral whose DS pin port is to be looked up.
  *
  * \return The SPI peripheral's DS pin port.
  */
-inline auto ds_port( Peripheral::SPI const & usart ) noexcept -> Peripheral::PORT &
+inline auto ds_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
+    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
         case Peripheral::ATmega2560::SPI0::ADDRESS:
             return Peripheral::ATmega2560::PORTB::instance();
     } // switch
@@ -59,13 +59,13 @@ inline auto ds_port( Peripheral::SPI const & usart ) noexcept -> Peripheral::POR
  *            compiler flag to `atmega2560` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::ds_number().
  *
- * \param[in] usart The SPI peripheral whose DS pin number is to be looked up.
+ * \param[in] spi The SPI peripheral whose DS pin number is to be looked up.
  *
  * \return The SPI peripheral's DS pin number.
  */
-inline auto ds_number( Peripheral::SPI const & usart ) noexcept -> std::uint_fast8_t
+inline auto ds_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast8_t
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
+    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
         case Peripheral::ATmega2560::SPI0::ADDRESS: return 0;
     } // switch
 
@@ -79,13 +79,13 @@ inline auto ds_number( Peripheral::SPI const & usart ) noexcept -> std::uint_fas
  *            compiler flag to `atmega2560` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::ds_mask().
  *
- * \param[in] usart The SPI peripheral whose DS pin mask is to be looked up.
+ * \param[in] spi The SPI peripheral whose DS pin mask is to be looked up.
  *
  * \return The SPI peripheral's DS pin mask.
  */
-inline auto ds_mask( Peripheral::SPI const & usart ) noexcept -> std::uint8_t
+inline auto ds_mask( Peripheral::SPI const & spi ) noexcept -> std::uint8_t
 {
-    return 1 << ds_number( usart );
+    return 1 << ds_number( spi );
 }
 
 /**
@@ -95,13 +95,13 @@ inline auto ds_mask( Peripheral::SPI const & usart ) noexcept -> std::uint8_t
  *            compiler flag to `atmega2560` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::sck_port().
  *
- * \param[in] usart The SPI peripheral whose SCK pin port is to be looked up.
+ * \param[in] spi The SPI peripheral whose SCK pin port is to be looked up.
  *
  * \return The SPI peripheral's SCK pin port.
  */
-inline auto sck_port( Peripheral::SPI const & usart ) noexcept -> Peripheral::PORT &
+inline auto sck_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
+    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
         case Peripheral::ATmega2560::SPI0::ADDRESS:
             return Peripheral::ATmega2560::PORTB::instance();
     } // switch
@@ -116,13 +116,13 @@ inline auto sck_port( Peripheral::SPI const & usart ) noexcept -> Peripheral::PO
  *            compiler flag to `atmega2560` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::sck_number().
  *
- * \param[in] usart The SPI peripheral whose SCK pin number is to be looked up.
+ * \param[in] spi The SPI peripheral whose SCK pin number is to be looked up.
  *
  * \return The SPI peripheral's SCK pin number.
  */
-inline auto sck_number( Peripheral::SPI const & usart ) noexcept -> std::uint_fast8_t
+inline auto sck_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast8_t
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
+    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
         case Peripheral::ATmega2560::SPI0::ADDRESS: return 1;
     } // switch
 
@@ -136,13 +136,13 @@ inline auto sck_number( Peripheral::SPI const & usart ) noexcept -> std::uint_fa
  *            compiler flag to `atmega2560` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::sck_mask().
  *
- * \param[in] usart The SPI peripheral whose SCK pin mask is to be looked up.
+ * \param[in] spi The SPI peripheral whose SCK pin mask is to be looked up.
  *
  * \return The SPI peripheral's SCK pin mask.
  */
-inline auto sck_mask( Peripheral::SPI const & usart ) noexcept -> std::uint8_t
+inline auto sck_mask( Peripheral::SPI const & spi ) noexcept -> std::uint8_t
 {
-    return 1 << sck_number( usart );
+    return 1 << sck_number( spi );
 }
 
 /**
@@ -152,13 +152,13 @@ inline auto sck_mask( Peripheral::SPI const & usart ) noexcept -> std::uint8_t
  *            compiler flag to `atmega2560` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::codi_port().
  *
- * \param[in] usart The SPI peripheral whose CODI pin port is to be looked up.
+ * \param[in] spi The SPI peripheral whose CODI pin port is to be looked up.
  *
  * \return The SPI peripheral's CODI pin port.
  */
-inline auto codi_port( Peripheral::SPI const & usart ) noexcept -> Peripheral::PORT &
+inline auto codi_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
+    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
         case Peripheral::ATmega2560::SPI0::ADDRESS:
             return Peripheral::ATmega2560::PORTB::instance();
     } // switch
@@ -173,13 +173,13 @@ inline auto codi_port( Peripheral::SPI const & usart ) noexcept -> Peripheral::P
  *            compiler flag to `atmega2560` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::codi_number().
  *
- * \param[in] usart The SPI peripheral whose CODI pin number is to be looked up.
+ * \param[in] spi The SPI peripheral whose CODI pin number is to be looked up.
  *
  * \return The SPI peripheral's CODI pin number.
  */
-inline auto codi_number( Peripheral::SPI const & usart ) noexcept -> std::uint_fast8_t
+inline auto codi_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast8_t
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
+    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
         case Peripheral::ATmega2560::SPI0::ADDRESS: return 2;
     } // switch
 
@@ -193,13 +193,13 @@ inline auto codi_number( Peripheral::SPI const & usart ) noexcept -> std::uint_f
  *            compiler flag to `atmega2560` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::codi_mask().
  *
- * \param[in] usart The SPI peripheral whose CODI pin mask is to be looked up.
+ * \param[in] spi The SPI peripheral whose CODI pin mask is to be looked up.
  *
  * \return The SPI peripheral's CODI pin mask.
  */
-inline auto codi_mask( Peripheral::SPI const & usart ) noexcept -> std::uint8_t
+inline auto codi_mask( Peripheral::SPI const & spi ) noexcept -> std::uint8_t
 {
-    return 1 << codi_number( usart );
+    return 1 << codi_number( spi );
 }
 
 /**
@@ -209,13 +209,13 @@ inline auto codi_mask( Peripheral::SPI const & usart ) noexcept -> std::uint8_t
  *            compiler flag to `atmega2560` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::cido_port().
  *
- * \param[in] usart The SPI peripheral whose CIDO pin port is to be looked up.
+ * \param[in] spi The SPI peripheral whose CIDO pin port is to be looked up.
  *
  * \return The SPI peripheral's CIDO pin port.
  */
-inline auto cido_port( Peripheral::SPI const & usart ) noexcept -> Peripheral::PORT &
+inline auto cido_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
+    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
         case Peripheral::ATmega2560::SPI0::ADDRESS:
             return Peripheral::ATmega2560::PORTB::instance();
     } // switch
@@ -230,13 +230,13 @@ inline auto cido_port( Peripheral::SPI const & usart ) noexcept -> Peripheral::P
  *            compiler flag to `atmega2560` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::cido_number().
  *
- * \param[in] usart The SPI peripheral whose CIDO pin number is to be looked up.
+ * \param[in] spi The SPI peripheral whose CIDO pin number is to be looked up.
  *
  * \return The SPI peripheral's CIDO pin number.
  */
-inline auto cido_number( Peripheral::SPI const & usart ) noexcept -> std::uint_fast8_t
+inline auto cido_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast8_t
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
+    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
         case Peripheral::ATmega2560::SPI0::ADDRESS: return 3;
     } // switch
 
@@ -250,13 +250,13 @@ inline auto cido_number( Peripheral::SPI const & usart ) noexcept -> std::uint_f
  *            compiler flag to `atmega2560` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::cido_mask().
  *
- * \param[in] usart The SPI peripheral whose CIDO pin mask is to be looked up.
+ * \param[in] spi The SPI peripheral whose CIDO pin mask is to be looked up.
  *
  * \return The SPI peripheral's CIDO pin mask.
  */
-inline auto cido_mask( Peripheral::SPI const & usart ) noexcept -> std::uint8_t
+inline auto cido_mask( Peripheral::SPI const & spi ) noexcept -> std::uint8_t
 {
-    return 1 << cido_number( usart );
+    return 1 << cido_number( spi );
 }
 
 } // namespace picolibrary::Microchip::megaAVR::Multiplexed_Signals::ATmega2560

--- a/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega2560/twi.h
+++ b/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega2560/twi.h
@@ -38,13 +38,13 @@ namespace picolibrary::Microchip::megaAVR::Multiplexed_Signals::ATmega2560 {
  *            compiler flag to `atmega2560` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::scl_port().
  *
- * \param[in] usart The TWI peripheral whose SCL pin port is to be looked up.
+ * \param[in] twi The TWI peripheral whose SCL pin port is to be looked up.
  *
  * \return The TWI peripheral's SCL pin port.
  */
-inline auto scl_port( Peripheral::TWI const & usart ) noexcept -> Peripheral::PORT &
+inline auto scl_port( Peripheral::TWI const & twi ) noexcept -> Peripheral::PORT &
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
+    switch ( reinterpret_cast<std::uintptr_t>( &twi ) ) {
         case Peripheral::ATmega2560::TWI0::ADDRESS:
             return Peripheral::ATmega2560::PORTD::instance();
     } // switch
@@ -59,13 +59,13 @@ inline auto scl_port( Peripheral::TWI const & usart ) noexcept -> Peripheral::PO
  *            compiler flag to `atmega2560` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::scl_number().
  *
- * \param[in] usart The TWI peripheral whose SCL pin number is to be looked up.
+ * \param[in] twi The TWI peripheral whose SCL pin number is to be looked up.
  *
  * \return The TWI peripheral's SCL pin number.
  */
-inline auto scl_number( Peripheral::TWI const & usart ) noexcept -> std::uint_fast8_t
+inline auto scl_number( Peripheral::TWI const & twi ) noexcept -> std::uint_fast8_t
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
+    switch ( reinterpret_cast<std::uintptr_t>( &twi ) ) {
         case Peripheral::ATmega2560::TWI0::ADDRESS: return 0;
     } // switch
 
@@ -79,13 +79,13 @@ inline auto scl_number( Peripheral::TWI const & usart ) noexcept -> std::uint_fa
  *            compiler flag to `atmega2560` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::scl_mask().
  *
- * \param[in] usart The TWI peripheral whose SCL pin mask is to be looked up.
+ * \param[in] twi The TWI peripheral whose SCL pin mask is to be looked up.
  *
  * \return The TWI peripheral's SCL pin mask.
  */
-inline auto scl_mask( Peripheral::TWI const & usart ) noexcept -> std::uint8_t
+inline auto scl_mask( Peripheral::TWI const & twi ) noexcept -> std::uint8_t
 {
-    return 1 << scl_number( usart );
+    return 1 << scl_number( twi );
 }
 
 /**
@@ -95,13 +95,13 @@ inline auto scl_mask( Peripheral::TWI const & usart ) noexcept -> std::uint8_t
  *            compiler flag to `atmega2560` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::sda_port().
  *
- * \param[in] usart The TWI peripheral whose SDA pin port is to be looked up.
+ * \param[in] twi The TWI peripheral whose SDA pin port is to be looked up.
  *
  * \return The TWI peripheral's SDA pin port.
  */
-inline auto sda_port( Peripheral::TWI const & usart ) noexcept -> Peripheral::PORT &
+inline auto sda_port( Peripheral::TWI const & twi ) noexcept -> Peripheral::PORT &
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
+    switch ( reinterpret_cast<std::uintptr_t>( &twi ) ) {
         case Peripheral::ATmega2560::TWI0::ADDRESS:
             return Peripheral::ATmega2560::PORTD::instance();
     } // switch
@@ -116,13 +116,13 @@ inline auto sda_port( Peripheral::TWI const & usart ) noexcept -> Peripheral::PO
  *            compiler flag to `atmega2560` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::sda_number().
  *
- * \param[in] usart The TWI peripheral whose SDA pin number is to be looked up.
+ * \param[in] twi The TWI peripheral whose SDA pin number is to be looked up.
  *
  * \return The TWI peripheral's SDA pin number.
  */
-inline auto sda_number( Peripheral::TWI const & usart ) noexcept -> std::uint_fast8_t
+inline auto sda_number( Peripheral::TWI const & twi ) noexcept -> std::uint_fast8_t
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
+    switch ( reinterpret_cast<std::uintptr_t>( &twi ) ) {
         case Peripheral::ATmega2560::TWI0::ADDRESS: return 1;
     } // switch
 
@@ -136,13 +136,13 @@ inline auto sda_number( Peripheral::TWI const & usart ) noexcept -> std::uint_fa
  *            compiler flag to `atmega2560` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::sda_mask().
  *
- * \param[in] usart The TWI peripheral whose SDA pin mask is to be looked up.
+ * \param[in] twi The TWI peripheral whose SDA pin mask is to be looked up.
  *
  * \return The TWI peripheral's SDA pin mask.
  */
-inline auto sda_mask( Peripheral::TWI const & usart ) noexcept -> std::uint8_t
+inline auto sda_mask( Peripheral::TWI const & twi ) noexcept -> std::uint8_t
 {
-    return 1 << sda_number( usart );
+    return 1 << sda_number( twi );
 }
 
 } // namespace picolibrary::Microchip::megaAVR::Multiplexed_Signals::ATmega2560

--- a/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p/spi.h
+++ b/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p/spi.h
@@ -38,13 +38,13 @@ namespace picolibrary::Microchip::megaAVR::Multiplexed_Signals::ATmega328P {
  *            compiler flag to `atmega328p` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::ds_port().
  *
- * \param[in] usart The SPI peripheral whose DS pin port is to be looked up.
+ * \param[in] spi The SPI peripheral whose DS pin port is to be looked up.
  *
  * \return The SPI peripheral's DS pin port.
  */
-inline auto ds_port( Peripheral::SPI const & usart ) noexcept -> Peripheral::PORT &
+inline auto ds_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
+    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
         case Peripheral::ATmega328P::SPI0::ADDRESS:
             return Peripheral::ATmega328P::PORTB::instance();
     } // switch
@@ -59,13 +59,13 @@ inline auto ds_port( Peripheral::SPI const & usart ) noexcept -> Peripheral::POR
  *            compiler flag to `atmega328p` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::ds_number().
  *
- * \param[in] usart The SPI peripheral whose DS pin number is to be looked up.
+ * \param[in] spi The SPI peripheral whose DS pin number is to be looked up.
  *
  * \return The SPI peripheral's DS pin number.
  */
-inline auto ds_number( Peripheral::SPI const & usart ) noexcept -> std::uint_fast8_t
+inline auto ds_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast8_t
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
+    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
         case Peripheral::ATmega328P::SPI0::ADDRESS: return 2;
     } // switch
 
@@ -79,13 +79,13 @@ inline auto ds_number( Peripheral::SPI const & usart ) noexcept -> std::uint_fas
  *            compiler flag to `atmega328p` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::ds_mask().
  *
- * \param[in] usart The SPI peripheral whose DS pin mask is to be looked up.
+ * \param[in] spi The SPI peripheral whose DS pin mask is to be looked up.
  *
  * \return The SPI peripheral's DS pin mask.
  */
-inline auto ds_mask( Peripheral::SPI const & usart ) noexcept -> std::uint8_t
+inline auto ds_mask( Peripheral::SPI const & spi ) noexcept -> std::uint8_t
 {
-    return 1 << ds_number( usart );
+    return 1 << ds_number( spi );
 }
 
 /**
@@ -95,13 +95,13 @@ inline auto ds_mask( Peripheral::SPI const & usart ) noexcept -> std::uint8_t
  *            compiler flag to `atmega328p` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::sck_port().
  *
- * \param[in] usart The SPI peripheral whose SCK pin port is to be looked up.
+ * \param[in] spi The SPI peripheral whose SCK pin port is to be looked up.
  *
  * \return The SPI peripheral's SCK pin port.
  */
-inline auto sck_port( Peripheral::SPI const & usart ) noexcept -> Peripheral::PORT &
+inline auto sck_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
+    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
         case Peripheral::ATmega328P::SPI0::ADDRESS:
             return Peripheral::ATmega328P::PORTB::instance();
     } // switch
@@ -116,13 +116,13 @@ inline auto sck_port( Peripheral::SPI const & usart ) noexcept -> Peripheral::PO
  *            compiler flag to `atmega328p` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::sck_number().
  *
- * \param[in] usart The SPI peripheral whose SCK pin number is to be looked up.
+ * \param[in] spi The SPI peripheral whose SCK pin number is to be looked up.
  *
  * \return The SPI peripheral's SCK pin number.
  */
-inline auto sck_number( Peripheral::SPI const & usart ) noexcept -> std::uint_fast8_t
+inline auto sck_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast8_t
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
+    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
         case Peripheral::ATmega328P::SPI0::ADDRESS: return 5;
     } // switch
 
@@ -136,13 +136,13 @@ inline auto sck_number( Peripheral::SPI const & usart ) noexcept -> std::uint_fa
  *            compiler flag to `atmega328p` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::sck_mask().
  *
- * \param[in] usart The SPI peripheral whose SCK pin mask is to be looked up.
+ * \param[in] spi The SPI peripheral whose SCK pin mask is to be looked up.
  *
  * \return The SPI peripheral's SCK pin mask.
  */
-inline auto sck_mask( Peripheral::SPI const & usart ) noexcept -> std::uint8_t
+inline auto sck_mask( Peripheral::SPI const & spi ) noexcept -> std::uint8_t
 {
-    return 1 << sck_number( usart );
+    return 1 << sck_number( spi );
 }
 
 /**
@@ -152,13 +152,13 @@ inline auto sck_mask( Peripheral::SPI const & usart ) noexcept -> std::uint8_t
  *            compiler flag to `atmega328p` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::codi_port().
  *
- * \param[in] usart The SPI peripheral whose CODI pin port is to be looked up.
+ * \param[in] spi The SPI peripheral whose CODI pin port is to be looked up.
  *
  * \return The SPI peripheral's CODI pin port.
  */
-inline auto codi_port( Peripheral::SPI const & usart ) noexcept -> Peripheral::PORT &
+inline auto codi_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
+    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
         case Peripheral::ATmega328P::SPI0::ADDRESS:
             return Peripheral::ATmega328P::PORTB::instance();
     } // switch
@@ -173,13 +173,13 @@ inline auto codi_port( Peripheral::SPI const & usart ) noexcept -> Peripheral::P
  *            compiler flag to `atmega328p` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::codi_number().
  *
- * \param[in] usart The SPI peripheral whose CODI pin number is to be looked up.
+ * \param[in] spi The SPI peripheral whose CODI pin number is to be looked up.
  *
  * \return The SPI peripheral's CODI pin number.
  */
-inline auto codi_number( Peripheral::SPI const & usart ) noexcept -> std::uint_fast8_t
+inline auto codi_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast8_t
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
+    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
         case Peripheral::ATmega328P::SPI0::ADDRESS: return 3;
     } // switch
 
@@ -193,13 +193,13 @@ inline auto codi_number( Peripheral::SPI const & usart ) noexcept -> std::uint_f
  *            compiler flag to `atmega328p` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::codi_mask().
  *
- * \param[in] usart The SPI peripheral whose CODI pin mask is to be looked up.
+ * \param[in] spi The SPI peripheral whose CODI pin mask is to be looked up.
  *
  * \return The SPI peripheral's CODI pin mask.
  */
-inline auto codi_mask( Peripheral::SPI const & usart ) noexcept -> std::uint8_t
+inline auto codi_mask( Peripheral::SPI const & spi ) noexcept -> std::uint8_t
 {
-    return 1 << codi_number( usart );
+    return 1 << codi_number( spi );
 }
 
 /**
@@ -209,13 +209,13 @@ inline auto codi_mask( Peripheral::SPI const & usart ) noexcept -> std::uint8_t
  *            compiler flag to `atmega328p` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::cido_port().
  *
- * \param[in] usart The SPI peripheral whose CIDO pin port is to be looked up.
+ * \param[in] spi The SPI peripheral whose CIDO pin port is to be looked up.
  *
  * \return The SPI peripheral's CIDO pin port.
  */
-inline auto cido_port( Peripheral::SPI const & usart ) noexcept -> Peripheral::PORT &
+inline auto cido_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
+    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
         case Peripheral::ATmega328P::SPI0::ADDRESS:
             return Peripheral::ATmega328P::PORTB::instance();
     } // switch
@@ -230,13 +230,13 @@ inline auto cido_port( Peripheral::SPI const & usart ) noexcept -> Peripheral::P
  *            compiler flag to `atmega328p` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::cido_number().
  *
- * \param[in] usart The SPI peripheral whose CIDO pin number is to be looked up.
+ * \param[in] spi The SPI peripheral whose CIDO pin number is to be looked up.
  *
  * \return The SPI peripheral's CIDO pin number.
  */
-inline auto cido_number( Peripheral::SPI const & usart ) noexcept -> std::uint_fast8_t
+inline auto cido_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast8_t
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
+    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
         case Peripheral::ATmega328P::SPI0::ADDRESS: return 4;
     } // switch
 
@@ -250,13 +250,13 @@ inline auto cido_number( Peripheral::SPI const & usart ) noexcept -> std::uint_f
  *            compiler flag to `atmega328p` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::cido_mask().
  *
- * \param[in] usart The SPI peripheral whose CIDO pin mask is to be looked up.
+ * \param[in] spi The SPI peripheral whose CIDO pin mask is to be looked up.
  *
  * \return The SPI peripheral's CIDO pin mask.
  */
-inline auto cido_mask( Peripheral::SPI const & usart ) noexcept -> std::uint8_t
+inline auto cido_mask( Peripheral::SPI const & spi ) noexcept -> std::uint8_t
 {
-    return 1 << cido_number( usart );
+    return 1 << cido_number( spi );
 }
 
 } // namespace picolibrary::Microchip::megaAVR::Multiplexed_Signals::ATmega328P

--- a/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p/twi.h
+++ b/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p/twi.h
@@ -38,13 +38,13 @@ namespace picolibrary::Microchip::megaAVR::Multiplexed_Signals::ATmega328P {
  *            compiler flag to `atmega328p` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::scl_port().
  *
- * \param[in] usart The TWI peripheral whose SCL pin port is to be looked up.
+ * \param[in] twi The TWI peripheral whose SCL pin port is to be looked up.
  *
  * \return The TWI peripheral's SCL pin port.
  */
-inline auto scl_port( Peripheral::TWI const & usart ) noexcept -> Peripheral::PORT &
+inline auto scl_port( Peripheral::TWI const & twi ) noexcept -> Peripheral::PORT &
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
+    switch ( reinterpret_cast<std::uintptr_t>( &twi ) ) {
         case Peripheral::ATmega328P::TWI0::ADDRESS:
             return Peripheral::ATmega328P::PORTC::instance();
     } // switch
@@ -59,13 +59,13 @@ inline auto scl_port( Peripheral::TWI const & usart ) noexcept -> Peripheral::PO
  *            compiler flag to `atmega328p` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::scl_number().
  *
- * \param[in] usart The TWI peripheral whose SCL pin number is to be looked up.
+ * \param[in] twi The TWI peripheral whose SCL pin number is to be looked up.
  *
  * \return The TWI peripheral's SCL pin number.
  */
-inline auto scl_number( Peripheral::TWI const & usart ) noexcept -> std::uint_fast8_t
+inline auto scl_number( Peripheral::TWI const & twi ) noexcept -> std::uint_fast8_t
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
+    switch ( reinterpret_cast<std::uintptr_t>( &twi ) ) {
         case Peripheral::ATmega328P::TWI0::ADDRESS: return 5;
     } // switch
 
@@ -79,13 +79,13 @@ inline auto scl_number( Peripheral::TWI const & usart ) noexcept -> std::uint_fa
  *            compiler flag to `atmega328p` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::scl_mask().
  *
- * \param[in] usart The TWI peripheral whose SCL pin mask is to be looked up.
+ * \param[in] twi The TWI peripheral whose SCL pin mask is to be looked up.
  *
  * \return The TWI peripheral's SCL pin mask.
  */
-inline auto scl_mask( Peripheral::TWI const & usart ) noexcept -> std::uint8_t
+inline auto scl_mask( Peripheral::TWI const & twi ) noexcept -> std::uint8_t
 {
-    return 1 << scl_number( usart );
+    return 1 << scl_number( twi );
 }
 
 /**
@@ -95,13 +95,13 @@ inline auto scl_mask( Peripheral::TWI const & usart ) noexcept -> std::uint8_t
  *            compiler flag to `atmega328p` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::sda_port().
  *
- * \param[in] usart The TWI peripheral whose SDA pin port is to be looked up.
+ * \param[in] twi The TWI peripheral whose SDA pin port is to be looked up.
  *
  * \return The TWI peripheral's SDA pin port.
  */
-inline auto sda_port( Peripheral::TWI const & usart ) noexcept -> Peripheral::PORT &
+inline auto sda_port( Peripheral::TWI const & twi ) noexcept -> Peripheral::PORT &
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
+    switch ( reinterpret_cast<std::uintptr_t>( &twi ) ) {
         case Peripheral::ATmega328P::TWI0::ADDRESS:
             return Peripheral::ATmega328P::PORTC::instance();
     } // switch
@@ -116,13 +116,13 @@ inline auto sda_port( Peripheral::TWI const & usart ) noexcept -> Peripheral::PO
  *            compiler flag to `atmega328p` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::sda_number().
  *
- * \param[in] usart The TWI peripheral whose SDA pin number is to be looked up.
+ * \param[in] twi The TWI peripheral whose SDA pin number is to be looked up.
  *
  * \return The TWI peripheral's SDA pin number.
  */
-inline auto sda_number( Peripheral::TWI const & usart ) noexcept -> std::uint_fast8_t
+inline auto sda_number( Peripheral::TWI const & twi ) noexcept -> std::uint_fast8_t
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
+    switch ( reinterpret_cast<std::uintptr_t>( &twi ) ) {
         case Peripheral::ATmega328P::TWI0::ADDRESS: return 4;
     } // switch
 
@@ -136,13 +136,13 @@ inline auto sda_number( Peripheral::TWI const & usart ) noexcept -> std::uint_fa
  *            compiler flag to `atmega328p` and call
  *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::sda_mask().
  *
- * \param[in] usart The TWI peripheral whose SDA pin mask is to be looked up.
+ * \param[in] twi The TWI peripheral whose SDA pin mask is to be looked up.
  *
  * \return The TWI peripheral's SDA pin mask.
  */
-inline auto sda_mask( Peripheral::TWI const & usart ) noexcept -> std::uint8_t
+inline auto sda_mask( Peripheral::TWI const & twi ) noexcept -> std::uint8_t
 {
-    return 1 << sda_number( usart );
+    return 1 << sda_number( twi );
 }
 
 } // namespace picolibrary::Microchip::megaAVR::Multiplexed_Signals::ATmega328P


### PR DESCRIPTION
Resolves #249 (Fix multiplexed signals lookup function parameter
naming).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
