### PR TITLE
Eliminate multiplexed signals pin port lookup code duplication

### DIFF
--- a/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega2560/spi.h
+++ b/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega2560/spi.h
@@ -32,6 +32,27 @@
 namespace picolibrary::Microchip::megaAVR::Multiplexed_Signals::ATmega2560 {
 
 /**
+ * \brief Lookup an SPI peripheral's pins port.
+ *
+ * \attention This function should never be called directly. Instead, set the `-mmcu`
+ *            compiler flag to `atmega2560` and call
+ *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::spi_port().
+ *
+ * \param[in] spi The SPI peripheral whose pins port is to be looked up.
+ *
+ * \return The SPI peripheral's pins port.
+ */
+inline auto spi_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
+{
+    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
+        case Peripheral::ATmega2560::SPI0::ADDRESS:
+            return Peripheral::ATmega2560::PORTB::instance();
+    } // switch
+
+    return *static_cast<Peripheral::PORT *>( nullptr );
+}
+
+/**
  * \brief Lookup an SPI peripheral's DS pin port.
  *
  * \attention This function should never be called directly. Instead, set the `-mmcu`
@@ -42,14 +63,9 @@ namespace picolibrary::Microchip::megaAVR::Multiplexed_Signals::ATmega2560 {
  *
  * \return The SPI peripheral's DS pin port.
  */
-inline auto ds_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
+inline auto & ds_port( Peripheral::SPI const & spi ) noexcept
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
-        case Peripheral::ATmega2560::SPI0::ADDRESS:
-            return Peripheral::ATmega2560::PORTB::instance();
-    } // switch
-
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    return spi_port( spi );
 }
 
 /**
@@ -99,14 +115,9 @@ inline auto ds_mask( Peripheral::SPI const & spi ) noexcept -> std::uint8_t
  *
  * \return The SPI peripheral's SCK pin port.
  */
-inline auto sck_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
+inline auto & sck_port( Peripheral::SPI const & spi ) noexcept
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
-        case Peripheral::ATmega2560::SPI0::ADDRESS:
-            return Peripheral::ATmega2560::PORTB::instance();
-    } // switch
-
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    return spi_port( spi );
 }
 
 /**
@@ -156,14 +167,9 @@ inline auto sck_mask( Peripheral::SPI const & spi ) noexcept -> std::uint8_t
  *
  * \return The SPI peripheral's CODI pin port.
  */
-inline auto codi_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
+inline auto & codi_port( Peripheral::SPI const & spi ) noexcept
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
-        case Peripheral::ATmega2560::SPI0::ADDRESS:
-            return Peripheral::ATmega2560::PORTB::instance();
-    } // switch
-
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    return spi_port( spi );
 }
 
 /**
@@ -213,14 +219,9 @@ inline auto codi_mask( Peripheral::SPI const & spi ) noexcept -> std::uint8_t
  *
  * \return The SPI peripheral's CIDO pin port.
  */
-inline auto cido_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
+inline auto & cido_port( Peripheral::SPI const & spi ) noexcept
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
-        case Peripheral::ATmega2560::SPI0::ADDRESS:
-            return Peripheral::ATmega2560::PORTB::instance();
-    } // switch
-
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    return spi_port( spi );
 }
 
 /**

--- a/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega2560/twi.h
+++ b/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega2560/twi.h
@@ -32,6 +32,27 @@
 namespace picolibrary::Microchip::megaAVR::Multiplexed_Signals::ATmega2560 {
 
 /**
+ * \brief Lookup a TWI peripheral's pins port.
+ *
+ * \attention This function should never be called directly. Instead, set the `-mmcu`
+ *            compiler flag to `atmega2560` and call
+ *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::twi_port().
+ *
+ * \param[in] twi The TWI peripheral whose pins port is to be looked up.
+ *
+ * \return The TWI peripheral's pins port.
+ */
+inline auto twi_port( Peripheral::TWI const & twi ) noexcept -> Peripheral::PORT &
+{
+    switch ( reinterpret_cast<std::uintptr_t>( &twi ) ) {
+        case Peripheral::ATmega2560::TWI0::ADDRESS:
+            return Peripheral::ATmega2560::PORTD::instance();
+    } // switch
+
+    return *static_cast<Peripheral::PORT *>( nullptr );
+}
+
+/**
  * \brief Lookup a TWI peripheral's SCL pin port.
  *
  * \attention This function should never be called directly. Instead, set the `-mmcu`
@@ -42,14 +63,9 @@ namespace picolibrary::Microchip::megaAVR::Multiplexed_Signals::ATmega2560 {
  *
  * \return The TWI peripheral's SCL pin port.
  */
-inline auto scl_port( Peripheral::TWI const & twi ) noexcept -> Peripheral::PORT &
+inline auto & scl_port( Peripheral::TWI const & twi ) noexcept
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &twi ) ) {
-        case Peripheral::ATmega2560::TWI0::ADDRESS:
-            return Peripheral::ATmega2560::PORTD::instance();
-    } // switch
-
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    return twi_port( twi );
 }
 
 /**
@@ -99,14 +115,9 @@ inline auto scl_mask( Peripheral::TWI const & twi ) noexcept -> std::uint8_t
  *
  * \return The TWI peripheral's SDA pin port.
  */
-inline auto sda_port( Peripheral::TWI const & twi ) noexcept -> Peripheral::PORT &
+inline auto & sda_port( Peripheral::TWI const & twi ) noexcept
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &twi ) ) {
-        case Peripheral::ATmega2560::TWI0::ADDRESS:
-            return Peripheral::ATmega2560::PORTD::instance();
-    } // switch
-
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    return twi_port( twi );
 }
 
 /**

--- a/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega2560/usart.h
+++ b/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega2560/usart.h
@@ -33,17 +33,17 @@
 namespace picolibrary::Microchip::megaAVR::Multiplexed_Signals::ATmega2560 {
 
 /**
- * \brief Lookup a USART peripheral's XCK pin port.
+ * \brief Lookup a USART peripheral's pins port.
  *
  * \attention This function should never be called directly. Instead, set the `-mmcu`
  *            compiler flag to `atmega2560` and call
- *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::xck_port().
+ *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::usart_port().
  *
- * \param[in] usart The USART peripheral whose XCK pin port is to be looked up.
+ * \param[in] usart The USART peripheral whose pins port is to be looked up.
  *
- * \return The USART peripheral's XCK pin port.
+ * \return The USART peripheral's pins port.
  */
-inline auto xck_port( Peripheral::USART const & usart ) noexcept -> Peripheral::PORT &
+inline auto usart_port( Peripheral::USART const & usart ) noexcept -> Peripheral::PORT &
 {
     switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
         case Peripheral::ATmega2560::USART0::ADDRESS:
@@ -57,6 +57,22 @@ inline auto xck_port( Peripheral::USART const & usart ) noexcept -> Peripheral::
     } // switch
 
     return *static_cast<Peripheral::PORT *>( nullptr );
+}
+
+/**
+ * \brief Lookup a USART peripheral's XCK pin port.
+ *
+ * \attention This function should never be called directly. Instead, set the `-mmcu`
+ *            compiler flag to `atmega2560` and call
+ *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::xck_port().
+ *
+ * \param[in] usart The USART peripheral whose XCK pin port is to be looked up.
+ *
+ * \return The USART peripheral's XCK pin port.
+ */
+inline auto & xck_port( Peripheral::USART const & usart ) noexcept
+{
+    return usart_port( usart );
 }
 
 /**
@@ -109,20 +125,9 @@ inline auto xck_mask( Peripheral::USART const & usart ) noexcept -> std::uint8_t
  *
  * \return The USART peripheral's TXD pin port.
  */
-inline auto txd_port( Peripheral::USART const & usart ) noexcept -> Peripheral::PORT &
+inline auto & txd_port( Peripheral::USART const & usart ) noexcept
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
-        case Peripheral::ATmega2560::USART0::ADDRESS:
-            return Peripheral::ATmega2560::PORTE::instance();
-        case Peripheral::ATmega2560::USART1::ADDRESS:
-            return Peripheral::ATmega2560::PORTD::instance();
-        case Peripheral::ATmega2560::USART2::ADDRESS:
-            return Peripheral::ATmega2560::PORTH::instance();
-        case Peripheral::ATmega2560::USART3::ADDRESS:
-            return Peripheral::ATmega2560::PORTJ::instance();
-    } // switch
-
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    return usart_port( usart );
 }
 
 /**
@@ -175,20 +180,9 @@ inline auto txd_mask( Peripheral::USART const & usart ) noexcept -> std::uint8_t
  *
  * \return The USART peripheral's RXD pin port.
  */
-inline auto rxd_port( Peripheral::USART const & usart ) noexcept -> Peripheral::PORT &
+inline auto & rxd_port( Peripheral::USART const & usart ) noexcept
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
-        case Peripheral::ATmega2560::USART0::ADDRESS:
-            return Peripheral::ATmega2560::PORTE::instance();
-        case Peripheral::ATmega2560::USART1::ADDRESS:
-            return Peripheral::ATmega2560::PORTD::instance();
-        case Peripheral::ATmega2560::USART2::ADDRESS:
-            return Peripheral::ATmega2560::PORTH::instance();
-        case Peripheral::ATmega2560::USART3::ADDRESS:
-            return Peripheral::ATmega2560::PORTJ::instance();
-    } // switch
-
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    return usart_port( usart );
 }
 
 /**

--- a/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p/spi.h
+++ b/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p/spi.h
@@ -32,6 +32,27 @@
 namespace picolibrary::Microchip::megaAVR::Multiplexed_Signals::ATmega328P {
 
 /**
+ * \brief Lookup an SPI peripheral's pins port.
+ *
+ * \attention This function should never be called directly. Instead, set the `-mmcu`
+ *            compiler flag to `atmega328p` and call
+ *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::spi_port().
+ *
+ * \param[in] spi The SPI peripheral whose pins port is to be looked up.
+ *
+ * \return The SPI peripheral's pins port.
+ */
+inline auto spi_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
+{
+    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
+        case Peripheral::ATmega328P::SPI0::ADDRESS:
+            return Peripheral::ATmega328P::PORTB::instance();
+    } // switch
+
+    return *static_cast<Peripheral::PORT *>( nullptr );
+}
+
+/**
  * \brief Lookup an SPI peripheral's DS pin port.
  *
  * \attention This function should never be called directly. Instead, set the `-mmcu`
@@ -42,14 +63,9 @@ namespace picolibrary::Microchip::megaAVR::Multiplexed_Signals::ATmega328P {
  *
  * \return The SPI peripheral's DS pin port.
  */
-inline auto ds_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
+inline auto & ds_port( Peripheral::SPI const & spi ) noexcept
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
-        case Peripheral::ATmega328P::SPI0::ADDRESS:
-            return Peripheral::ATmega328P::PORTB::instance();
-    } // switch
-
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    return spi_port( spi );
 }
 
 /**
@@ -99,14 +115,9 @@ inline auto ds_mask( Peripheral::SPI const & spi ) noexcept -> std::uint8_t
  *
  * \return The SPI peripheral's SCK pin port.
  */
-inline auto sck_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
+inline auto & sck_port( Peripheral::SPI const & spi ) noexcept
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
-        case Peripheral::ATmega328P::SPI0::ADDRESS:
-            return Peripheral::ATmega328P::PORTB::instance();
-    } // switch
-
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    return spi_port( spi );
 }
 
 /**
@@ -156,14 +167,9 @@ inline auto sck_mask( Peripheral::SPI const & spi ) noexcept -> std::uint8_t
  *
  * \return The SPI peripheral's CODI pin port.
  */
-inline auto codi_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
+inline auto & codi_port( Peripheral::SPI const & spi ) noexcept
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
-        case Peripheral::ATmega328P::SPI0::ADDRESS:
-            return Peripheral::ATmega328P::PORTB::instance();
-    } // switch
-
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    return spi_port( spi );
 }
 
 /**
@@ -213,14 +219,9 @@ inline auto codi_mask( Peripheral::SPI const & spi ) noexcept -> std::uint8_t
  *
  * \return The SPI peripheral's CIDO pin port.
  */
-inline auto cido_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
+inline auto & cido_port( Peripheral::SPI const & spi ) noexcept
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
-        case Peripheral::ATmega328P::SPI0::ADDRESS:
-            return Peripheral::ATmega328P::PORTB::instance();
-    } // switch
-
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    return spi_port( spi );
 }
 
 /**

--- a/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p/twi.h
+++ b/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p/twi.h
@@ -32,6 +32,27 @@
 namespace picolibrary::Microchip::megaAVR::Multiplexed_Signals::ATmega328P {
 
 /**
+ * \brief Lookup a TWI peripheral's pins port.
+ *
+ * \attention This function should never be called directly. Instead, set the `-mmcu`
+ *            compiler flag to `atmega328p` and call
+ *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::twi_port().
+ *
+ * \param[in] twi The TWI peripheral whose pins port is to be looked up.
+ *
+ * \return The TWI peripheral's pins port.
+ */
+inline auto twi_port( Peripheral::TWI const & twi ) noexcept -> Peripheral::PORT &
+{
+    switch ( reinterpret_cast<std::uintptr_t>( &twi ) ) {
+        case Peripheral::ATmega328P::TWI0::ADDRESS:
+            return Peripheral::ATmega328P::PORTC::instance();
+    } // switch
+
+    return *static_cast<Peripheral::PORT *>( nullptr );
+}
+
+/**
  * \brief Lookup a TWI peripheral's SCL pin port.
  *
  * \attention This function should never be called directly. Instead, set the `-mmcu`
@@ -42,14 +63,9 @@ namespace picolibrary::Microchip::megaAVR::Multiplexed_Signals::ATmega328P {
  *
  * \return The TWI peripheral's SCL pin port.
  */
-inline auto scl_port( Peripheral::TWI const & twi ) noexcept -> Peripheral::PORT &
+inline auto & scl_port( Peripheral::TWI const & twi ) noexcept
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &twi ) ) {
-        case Peripheral::ATmega328P::TWI0::ADDRESS:
-            return Peripheral::ATmega328P::PORTC::instance();
-    } // switch
-
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    return twi_port( twi );
 }
 
 /**
@@ -99,14 +115,9 @@ inline auto scl_mask( Peripheral::TWI const & twi ) noexcept -> std::uint8_t
  *
  * \return The TWI peripheral's SDA pin port.
  */
-inline auto sda_port( Peripheral::TWI const & twi ) noexcept -> Peripheral::PORT &
+inline auto & sda_port( Peripheral::TWI const & twi ) noexcept
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &twi ) ) {
-        case Peripheral::ATmega328P::TWI0::ADDRESS:
-            return Peripheral::ATmega328P::PORTC::instance();
-    } // switch
-
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    return twi_port( twi );
 }
 
 /**

--- a/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p/usart.h
+++ b/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p/usart.h
@@ -33,6 +33,27 @@
 namespace picolibrary::Microchip::megaAVR::Multiplexed_Signals::ATmega328P {
 
 /**
+ * \brief Lookup a USART peripheral's pins port.
+ *
+ * \attention This function should never be called directly. Instead, set the `-mmcu`
+ *            compiler flag to `atmega328p` and call
+ *            picolibrary::Microchip::megaAVR::Multiplexed_Signals::usart_port().
+ *
+ * \param[in] usart The USART peripheral whose pins port is to be looked up.
+ *
+ * \return The USART peripheral's pins port.
+ */
+inline auto usart_port( Peripheral::USART const & usart ) noexcept -> Peripheral::PORT &
+{
+    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
+        case Peripheral::ATmega328P::USART0::ADDRESS:
+            return Peripheral::ATmega328P::PORTD::instance();
+    } // switch
+
+    return *static_cast<Peripheral::PORT *>( nullptr );
+}
+
+/**
  * \brief Lookup a USART peripheral's XCK pin port.
  *
  * \attention This function should never be called directly. Instead, set the `-mmcu`
@@ -43,14 +64,9 @@ namespace picolibrary::Microchip::megaAVR::Multiplexed_Signals::ATmega328P {
  *
  * \return The USART peripheral's XCK pin port.
  */
-inline auto xck_port( Peripheral::USART const & usart ) noexcept -> Peripheral::PORT &
+inline auto & xck_port( Peripheral::USART const & usart ) noexcept
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
-        case Peripheral::ATmega328P::USART0::ADDRESS:
-            return Peripheral::ATmega328P::PORTD::instance();
-    } // switch
-
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    return usart_port( usart );
 }
 
 /**
@@ -100,14 +116,9 @@ inline auto xck_mask( Peripheral::USART const & usart ) noexcept -> std::uint8_t
  *
  * \return The USART peripheral's TXD pin port.
  */
-inline auto txd_port( Peripheral::USART const & usart ) noexcept -> Peripheral::PORT &
+inline auto & txd_port( Peripheral::USART const & usart ) noexcept
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
-        case Peripheral::ATmega328P::USART0::ADDRESS:
-            return Peripheral::ATmega328P::PORTD::instance();
-    } // switch
-
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    return usart_port( usart );
 }
 
 /**
@@ -157,14 +168,9 @@ inline auto txd_mask( Peripheral::USART const & usart ) noexcept -> std::uint8_t
  *
  * \return The USART peripheral's RXD pin port.
  */
-inline auto rxd_port( Peripheral::USART const & usart ) noexcept -> Peripheral::PORT &
+inline auto & rxd_port( Peripheral::USART const & usart ) noexcept
 {
-    switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
-        case Peripheral::ATmega328P::USART0::ADDRESS:
-            return Peripheral::ATmega328P::PORTD::instance();
-    } // switch
-
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    return usart_port( usart );
 }
 
 /**


### PR DESCRIPTION
Resolves #250 (Eliminate multiplexed signals pin port lookup code
duplication).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
