### PR TITLE
Add operating speed member type alias to asynchronous serial clock configuration

### DIFF
--- a/include/picolibrary/microchip/megaavr/asynchronous_serial.h
+++ b/include/picolibrary/microchip/megaavr/asynchronous_serial.h
@@ -40,9 +40,14 @@ namespace picolibrary::Microchip::megaAVR::Asynchronous_Serial {
  */
 struct Clock_Configuration {
     /**
+     * \brief Clock generator operating speed.
+     */
+    using Operating_Speed = Peripheral::USART::Operating_Speed;
+
+    /**
      * \brief The clock generator operating speed.
      */
-    Peripheral::USART::Operating_Speed operating_speed;
+    Operating_Speed operating_speed;
 
     /**
      * \brief The clock generator scaling factor.

--- a/test/interactive/picolibrary/asynchronous_serial/unbuffered_output_stream/hello_world/main.cc
+++ b/test/interactive/picolibrary/asynchronous_serial/unbuffered_output_stream/hello_world/main.cc
@@ -24,7 +24,6 @@
 #include "picolibrary/asynchronous_serial/stream.h"
 #include "picolibrary/microchip/megaavr/asynchronous_serial.h"
 #include "picolibrary/microchip/megaavr/peripheral.h"
-#include "picolibrary/microchip/megaavr/peripheral/usart.h"
 #include "picolibrary/testing/interactive/asynchronous_serial/stream.h"
 
 namespace {
@@ -32,8 +31,8 @@ namespace {
 using namespace ::picolibrary::Microchip::megaAVR::Peripheral;
 
 using ::picolibrary::Asynchronous_Serial::Unbuffered_Output_Stream;
+using ::picolibrary::Microchip::megaAVR::Asynchronous_Serial::Clock_Configuration;
 using ::picolibrary::Microchip::megaAVR::Asynchronous_Serial::Transmitter_8_N_1;
-using ::picolibrary::Microchip::megaAVR::Peripheral::USART;
 using ::picolibrary::Testing::Interactive::Asynchronous_Serial::Stream::hello_world;
 
 } // namespace
@@ -48,7 +47,7 @@ int main()
 {
     hello_world<Unbuffered_Output_Stream>( Transmitter_8_N_1{
         TRANSMITTER_USART::instance(),
-        { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+        { .operating_speed = Clock_Configuration::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
           .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } } );
 
     for ( ;; ) {}

--- a/test/interactive/picolibrary/microchip/mcp23008/internally_pulled_up_input_pin/state/main.cc
+++ b/test/interactive/picolibrary/microchip/mcp23008/internally_pulled_up_input_pin/state/main.cc
@@ -29,7 +29,6 @@
 #include "picolibrary/microchip/megaavr/i2c.h"
 #include "picolibrary/microchip/megaavr/peripheral.h"
 #include "picolibrary/microchip/megaavr/peripheral/twi.h"
-#include "picolibrary/microchip/megaavr/peripheral/usart.h"
 #include "picolibrary/testing/interactive/microchip/mcp23008.h"
 
 namespace {
@@ -38,10 +37,10 @@ using namespace ::picolibrary::Microchip::megaAVR::Peripheral;
 
 using ::picolibrary::Asynchronous_Serial::Unbuffered_Output_Stream;
 using ::picolibrary::I2C::Address;
+using ::picolibrary::Microchip::megaAVR::Asynchronous_Serial::Clock_Configuration;
 using ::picolibrary::Microchip::megaAVR::Asynchronous_Serial::Transmitter_8_N_1;
 using ::picolibrary::Microchip::megaAVR::I2C::Controller;
 using ::picolibrary::Microchip::megaAVR::Peripheral::TWI;
-using ::picolibrary::Microchip::megaAVR::Peripheral::USART;
 using ::picolibrary::Testing::Interactive::Microchip::MCP23008::state;
 
 } // namespace
@@ -56,7 +55,7 @@ int main()
 {
     state<Unbuffered_Output_Stream>(
         Transmitter_8_N_1{ TRANSMITTER_USART::instance(),
-                           { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+                           { .operating_speed = Clock_Configuration::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
                              .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } },
         Controller{ CONTROLLER_TWI::instance(),
                     { .prescaler = TWI::Prescaler::CONTROLLER_BIT_RATE_GENERATOR_PRESCALER,

--- a/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/main.cc
+++ b/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/main.cc
@@ -30,7 +30,6 @@
 #include "picolibrary/microchip/megaavr/i2c.h"
 #include "picolibrary/microchip/megaavr/peripheral.h"
 #include "picolibrary/microchip/megaavr/peripheral/twi.h"
-#include "picolibrary/microchip/megaavr/peripheral/usart.h"
 #include "picolibrary/testing/interactive/microchip/mcp23008.h"
 
 namespace {
@@ -40,10 +39,10 @@ using namespace ::picolibrary::Microchip::megaAVR::Peripheral;
 using ::picolibrary::Asynchronous_Serial::Unbuffered_Output_Stream;
 using ::picolibrary::I2C::Address;
 using ::picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin;
+using ::picolibrary::Microchip::megaAVR::Asynchronous_Serial::Clock_Configuration;
 using ::picolibrary::Microchip::megaAVR::Asynchronous_Serial::Transmitter_8_N_1;
 using ::picolibrary::Microchip::megaAVR::I2C::Controller;
 using ::picolibrary::Microchip::megaAVR::Peripheral::TWI;
-using ::picolibrary::Microchip::megaAVR::Peripheral::USART;
 using ::picolibrary::Testing::Interactive::Microchip::MCP23008::toggle;
 
 } // namespace
@@ -58,7 +57,7 @@ int main()
 {
     toggle<Unbuffered_Output_Stream, Open_Drain_IO_Pin>(
         Transmitter_8_N_1{ TRANSMITTER_USART::instance(),
-                           { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+                           { .operating_speed = Clock_Configuration::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
                              .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } },
         Controller{ CONTROLLER_TWI::instance(),
                     { .prescaler = TWI::Prescaler::CONTROLLER_BIT_RATE_GENERATOR_PRESCALER,

--- a/test/interactive/picolibrary/microchip/mcp23008/push_pull_io_pin/toggle/main.cc
+++ b/test/interactive/picolibrary/microchip/mcp23008/push_pull_io_pin/toggle/main.cc
@@ -30,7 +30,6 @@
 #include "picolibrary/microchip/megaavr/i2c.h"
 #include "picolibrary/microchip/megaavr/peripheral.h"
 #include "picolibrary/microchip/megaavr/peripheral/twi.h"
-#include "picolibrary/microchip/megaavr/peripheral/usart.h"
 #include "picolibrary/testing/interactive/microchip/mcp23008.h"
 
 namespace {
@@ -40,10 +39,10 @@ using namespace ::picolibrary::Microchip::megaAVR::Peripheral;
 using ::picolibrary::Asynchronous_Serial::Unbuffered_Output_Stream;
 using ::picolibrary::I2C::Address;
 using ::picolibrary::Microchip::MCP23008::Push_Pull_IO_Pin;
+using ::picolibrary::Microchip::megaAVR::Asynchronous_Serial::Clock_Configuration;
 using ::picolibrary::Microchip::megaAVR::Asynchronous_Serial::Transmitter_8_N_1;
 using ::picolibrary::Microchip::megaAVR::I2C::Controller;
 using ::picolibrary::Microchip::megaAVR::Peripheral::TWI;
-using ::picolibrary::Microchip::megaAVR::Peripheral::USART;
 using ::picolibrary::Testing::Interactive::Microchip::MCP23008::toggle;
 
 } // namespace
@@ -58,7 +57,7 @@ int main()
 {
     toggle<Unbuffered_Output_Stream, Push_Pull_IO_Pin>(
         Transmitter_8_N_1{ TRANSMITTER_USART::instance(),
-                           { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+                           { .operating_speed = Clock_Configuration::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
                              .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } },
         Controller{ CONTROLLER_TWI::instance(),
                     { .prescaler = TWI::Prescaler::CONTROLLER_BIT_RATE_GENERATOR_PRESCALER,

--- a/test/interactive/picolibrary/microchip/mcp3008/sample/main.cc
+++ b/test/interactive/picolibrary/microchip/mcp3008/sample/main.cc
@@ -30,7 +30,6 @@
 #include "picolibrary/microchip/megaavr/multiplexed_signals.h"
 #include "picolibrary/microchip/megaavr/peripheral.h"
 #include "picolibrary/microchip/megaavr/peripheral/spi.h"
-#include "picolibrary/microchip/megaavr/peripheral/usart.h"
 #include "picolibrary/microchip/megaavr/spi.h"
 #include "picolibrary/spi.h"
 #include "picolibrary/testing/interactive/microchip/mcp3008.h"
@@ -44,12 +43,12 @@ using ::picolibrary::GPIO::Active_Low_IO_Pin;
 using ::picolibrary::Microchip::MCP3008::Channel;
 using ::picolibrary::Microchip::MCP3008::Channel_Pair;
 using ::picolibrary::Microchip::MCP3008::Input;
+using ::picolibrary::Microchip::megaAVR::Asynchronous_Serial::Clock_Configuration;
 using ::picolibrary::Microchip::megaAVR::Asynchronous_Serial::Transmitter_8_N_1;
 using ::picolibrary::Microchip::megaAVR::GPIO::Push_Pull_IO_Pin;
 using ::picolibrary::Microchip::megaAVR::Multiplexed_Signals::ds_mask;
 using ::picolibrary::Microchip::megaAVR::Multiplexed_Signals::ds_port;
 using ::picolibrary::Microchip::megaAVR::Peripheral::SPI;
-using ::picolibrary::Microchip::megaAVR::Peripheral::USART;
 using ::picolibrary::SPI::GPIO_Output_Pin_Device_Selector;
 using ::picolibrary::Testing::Interactive::Microchip::MCP3008::sample;
 
@@ -68,7 +67,7 @@ int main()
 {
     sample<Unbuffered_Output_Stream>(
         Transmitter_8_N_1{ TRANSMITTER_USART::instance(),
-                           { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+                           { .operating_speed = Clock_Configuration::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
                              .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } },
         Controller{ CONTROLLER_SPI::instance() },
         { .clock_rate     = SPI::Clock_Rate::CONTROLLER_CLOCK_RATE,

--- a/test/interactive/picolibrary/microchip/megaavr/asynchronous_serial/transmitter_8_n_1/hello_world/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr/asynchronous_serial/transmitter_8_n_1/hello_world/main.cc
@@ -23,15 +23,14 @@
 
 #include "picolibrary/microchip/megaavr/asynchronous_serial.h"
 #include "picolibrary/microchip/megaavr/peripheral.h"
-#include "picolibrary/microchip/megaavr/peripheral/usart.h"
 #include "picolibrary/testing/interactive/asynchronous_serial.h"
 
 namespace {
 
 using namespace ::picolibrary::Microchip::megaAVR::Peripheral;
 
+using ::picolibrary::Microchip::megaAVR::Asynchronous_Serial::Clock_Configuration;
 using ::picolibrary::Microchip::megaAVR::Asynchronous_Serial::Transmitter_8_N_1;
-using ::picolibrary::Microchip::megaAVR::Peripheral::USART;
 using ::picolibrary::Testing::Interactive::Asynchronous_Serial::hello_world;
 
 } // namespace
@@ -47,7 +46,7 @@ int main()
 {
     hello_world( Transmitter_8_N_1{
         TRANSMITTER_USART::instance(),
-        { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+        { .operating_speed = Clock_Configuration::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
           .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } } );
 
     for ( ;; ) {}

--- a/test/interactive/picolibrary/microchip/megaavr/gpio/internally_pulled_up_input_pin/state/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr/gpio/internally_pulled_up_input_pin/state/main.cc
@@ -27,7 +27,6 @@
 #include "picolibrary/microchip/megaavr/asynchronous_serial.h"
 #include "picolibrary/microchip/megaavr/gpio.h"
 #include "picolibrary/microchip/megaavr/peripheral.h"
-#include "picolibrary/microchip/megaavr/peripheral/usart.h"
 #include "picolibrary/testing/interactive/gpio.h"
 
 namespace {
@@ -35,9 +34,9 @@ namespace {
 using namespace ::picolibrary::Microchip::megaAVR::Peripheral;
 
 using ::picolibrary::Asynchronous_Serial::Unbuffered_Output_Stream;
+using ::picolibrary::Microchip::megaAVR::Asynchronous_Serial::Clock_Configuration;
 using ::picolibrary::Microchip::megaAVR::Asynchronous_Serial::Transmitter_8_N_1;
 using ::picolibrary::Microchip::megaAVR::GPIO::Internally_Pulled_Up_Input_Pin;
-using ::picolibrary::Microchip::megaAVR::Peripheral::USART;
 using ::picolibrary::Testing::Interactive::GPIO::state;
 
 } // namespace
@@ -53,7 +52,7 @@ int main()
 {
     state<Unbuffered_Output_Stream>(
         Transmitter_8_N_1{ TRANSMITTER_USART::instance(),
-                           { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+                           { .operating_speed = Clock_Configuration::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
                              .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } },
         Internally_Pulled_Up_Input_Pin{ PIN_PORT::instance(), PIN_MASK },
         []() { avrlibcpp::delay_ms( 1000 ); } );

--- a/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/main.cc
@@ -27,7 +27,6 @@
 #include "picolibrary/microchip/megaavr/asynchronous_serial.h"
 #include "picolibrary/microchip/megaavr/gpio.h"
 #include "picolibrary/microchip/megaavr/peripheral.h"
-#include "picolibrary/microchip/megaavr/peripheral/usart.h"
 #include "picolibrary/testing/interactive/gpio.h"
 
 namespace {
@@ -35,9 +34,9 @@ namespace {
 using namespace ::picolibrary::Microchip::megaAVR::Peripheral;
 
 using ::picolibrary::Asynchronous_Serial::Unbuffered_Output_Stream;
+using ::picolibrary::Microchip::megaAVR::Asynchronous_Serial::Clock_Configuration;
 using ::picolibrary::Microchip::megaAVR::Asynchronous_Serial::Transmitter_8_N_1;
 using ::picolibrary::Microchip::megaAVR::GPIO::Open_Drain_IO_Pin;
-using ::picolibrary::Microchip::megaAVR::Peripheral::USART;
 using ::picolibrary::Testing::Interactive::GPIO::toggle;
 
 } // namespace
@@ -52,7 +51,7 @@ int main()
 {
     toggle<Unbuffered_Output_Stream>(
         Transmitter_8_N_1{ TRANSMITTER_USART::instance(),
-                           { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+                           { .operating_speed = Clock_Configuration::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
                              .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } },
         Open_Drain_IO_Pin{ PIN_PORT::instance(), PIN_MASK },
         []() { avrlibcpp::delay_ms( 500 ); } );

--- a/test/interactive/picolibrary/microchip/megaavr/gpio/push_pull_io_pin/toggle/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr/gpio/push_pull_io_pin/toggle/main.cc
@@ -27,7 +27,6 @@
 #include "picolibrary/microchip/megaavr/asynchronous_serial.h"
 #include "picolibrary/microchip/megaavr/gpio.h"
 #include "picolibrary/microchip/megaavr/peripheral.h"
-#include "picolibrary/microchip/megaavr/peripheral/usart.h"
 #include "picolibrary/testing/interactive/gpio.h"
 
 namespace {
@@ -35,9 +34,9 @@ namespace {
 using namespace ::picolibrary::Microchip::megaAVR::Peripheral;
 
 using ::picolibrary::Asynchronous_Serial::Unbuffered_Output_Stream;
+using ::picolibrary::Microchip::megaAVR::Asynchronous_Serial::Clock_Configuration;
 using ::picolibrary::Microchip::megaAVR::Asynchronous_Serial::Transmitter_8_N_1;
 using ::picolibrary::Microchip::megaAVR::GPIO::Push_Pull_IO_Pin;
-using ::picolibrary::Microchip::megaAVR::Peripheral::USART;
 using ::picolibrary::Testing::Interactive::GPIO::toggle;
 
 } // namespace
@@ -52,7 +51,7 @@ int main()
 {
     toggle<Unbuffered_Output_Stream>(
         Transmitter_8_N_1{ TRANSMITTER_USART::instance(),
-                           { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+                           { .operating_speed = Clock_Configuration::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
                              .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } },
         Push_Pull_IO_Pin{ PIN_PORT::instance(), PIN_MASK },
         []() { avrlibcpp::delay_ms( 500 ); } );

--- a/test/interactive/picolibrary/microchip/megaavr/i2c/controller/scan/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr/i2c/controller/scan/main.cc
@@ -25,7 +25,6 @@
 #include "picolibrary/microchip/megaavr/i2c.h"
 #include "picolibrary/microchip/megaavr/peripheral.h"
 #include "picolibrary/microchip/megaavr/peripheral/twi.h"
-#include "picolibrary/microchip/megaavr/peripheral/usart.h"
 #include "picolibrary/testing/interactive/i2c.h"
 
 namespace {
@@ -33,10 +32,10 @@ namespace {
 using namespace ::picolibrary::Microchip::megaAVR::Peripheral;
 
 using ::picolibrary::Asynchronous_Serial::Unbuffered_Output_Stream;
+using ::picolibrary::Microchip::megaAVR::Asynchronous_Serial::Clock_Configuration;
 using ::picolibrary::Microchip::megaAVR::Asynchronous_Serial::Transmitter_8_N_1;
 using ::picolibrary::Microchip::megaAVR::I2C::Controller;
 using ::picolibrary::Microchip::megaAVR::Peripheral::TWI;
-using ::picolibrary::Microchip::megaAVR::Peripheral::USART;
 using ::picolibrary::Testing::Interactive::I2C::scan;
 
 } // namespace
@@ -51,7 +50,7 @@ int main()
 {
     scan<Unbuffered_Output_Stream>(
         Transmitter_8_N_1{ TRANSMITTER_USART::instance(),
-                           { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+                           { .operating_speed = Clock_Configuration::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
                              .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } },
         Controller{ CONTROLLER_TWI::instance(),
                     { .prescaler = TWI::Prescaler::CONTROLLER_BIT_RATE_GENERATOR_PRESCALER,

--- a/test/interactive/picolibrary/microchip/megaavr/spi/controller/spi/echo/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr/spi/controller/spi/echo/main.cc
@@ -26,7 +26,6 @@
 #include "picolibrary/asynchronous_serial/stream.h"
 #include "picolibrary/microchip/megaavr/asynchronous_serial.h"
 #include "picolibrary/microchip/megaavr/peripheral.h"
-#include "picolibrary/microchip/megaavr/peripheral/usart.h"
 #include "picolibrary/microchip/megaavr/spi.h"
 #include "picolibrary/testing/interactive/spi.h"
 
@@ -35,9 +34,9 @@ namespace {
 using namespace ::picolibrary::Microchip::megaAVR::Peripheral;
 
 using ::picolibrary::Asynchronous_Serial::Unbuffered_Output_Stream;
+using ::picolibrary::Microchip::megaAVR::Asynchronous_Serial::Clock_Configuration;
 using ::picolibrary::Microchip::megaAVR::Asynchronous_Serial::Transmitter_8_N_1;
 using ::picolibrary::Microchip::megaAVR::Peripheral::SPI;
-using ::picolibrary::Microchip::megaAVR::Peripheral::USART;
 using ::picolibrary::Testing::Interactive::SPI::echo;
 
 using Controller = ::picolibrary::Microchip::megaAVR::SPI::Controller<SPI>;
@@ -55,7 +54,7 @@ int main()
 {
     echo<Unbuffered_Output_Stream>(
         Transmitter_8_N_1{ TRANSMITTER_USART::instance(),
-                           { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+                           { .operating_speed = Clock_Configuration::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
                              .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } },
         Controller{ CONTROLLER_SPI::instance() },
         { .clock_rate     = SPI::Clock_Rate::CONTROLLER_CLOCK_RATE,

--- a/test/interactive/picolibrary/microchip/megaavr/spi/controller/usart/echo/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr/spi/controller/usart/echo/main.cc
@@ -35,6 +35,7 @@ namespace {
 using namespace ::picolibrary::Microchip::megaAVR::Peripheral;
 
 using ::picolibrary::Asynchronous_Serial::Unbuffered_Output_Stream;
+using ::picolibrary::Microchip::megaAVR::Asynchronous_Serial::Clock_Configuration;
 using ::picolibrary::Microchip::megaAVR::Asynchronous_Serial::Transmitter_8_N_1;
 using ::picolibrary::Microchip::megaAVR::Peripheral::USART;
 using ::picolibrary::Testing::Interactive::SPI::echo;
@@ -54,7 +55,7 @@ int main()
 {
     echo<Unbuffered_Output_Stream>(
         Transmitter_8_N_1{ TRANSMITTER_USART::instance(),
-                           { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+                           { .operating_speed = Clock_Configuration::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
                              .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } },
         Controller{ CONTROLLER_USART::instance() },
         { .scaling_factor = CONTROLLER_SCALING_FACTOR,


### PR DESCRIPTION
Resolves #256 (Add operating speed member type alias to asynchronous
serial clock configuration).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
