### PR TITLE
Remove unnecessary hardware manipulation during GPIO open-drain I/O pin construction

### DIFF
--- a/include/picolibrary/microchip/megaavr/gpio.h
+++ b/include/picolibrary/microchip/megaavr/gpio.h
@@ -210,13 +210,10 @@ class Open_Drain_IO_Pin {
      * \param[in] port The GPIO port the pin is a member of.
      * \param[in] mask The mask identifying the pin.
      */
-    Open_Drain_IO_Pin( Peripheral::PORT & port, std::uint8_t mask ) noexcept :
+    constexpr Open_Drain_IO_Pin( Peripheral::PORT & port, std::uint8_t mask ) noexcept :
         m_port{ &port },
         m_mask{ mask }
     {
-        m_port->disable_pull_up( m_mask );
-
-        m_port->configure_pin_as_internally_pulled_up_input( m_mask );
     }
 
     /**


### PR DESCRIPTION
Resolves #258 (Remove unnecessary hardware manipulation during GPIO
open-drain I/O pin construction).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
