### PR TITLE
Disable SPI peripheral at start of initialization

### DIFF
--- a/include/picolibrary/microchip/megaavr/peripheral/spi.h
+++ b/include/picolibrary/microchip/megaavr/peripheral/spi.h
@@ -334,8 +334,8 @@ class SPI {
      */
     void configure_as_spi_controller() noexcept
     {
-        spsr.configure_as_spi_controller();
         spcr.configure_as_spi_controller();
+        spsr.configure_as_spi_controller();
     }
 
     /**
@@ -343,8 +343,8 @@ class SPI {
      */
     void configure_as_spi_device() noexcept
     {
-        spsr.configure_as_spi_device();
         spcr.configure_as_spi_device();
+        spsr.configure_as_spi_device();
     }
 
     /**


### PR DESCRIPTION
Resolves #270 (Disable SPI peripheral at start of initialization).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
