### PR TITLE
Remove unnecessary TWI disable call during I2C basic controller construction

### DIFF
--- a/include/picolibrary/microchip/megaavr/i2c.h
+++ b/include/picolibrary/microchip/megaavr/i2c.h
@@ -72,8 +72,6 @@ class Basic_Controller {
         :
         m_twi{ &twi }
     {
-        m_twi->disable();
-
         m_twi->configure_as_i2c_controller(
             bit_rate_generator_configuration.prescaler, bit_rate_generator_configuration.scaling_factor );
     }


### PR DESCRIPTION
Resolves #267 (Remove unnecessary TWI disable call during I2C basic
controller construction).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
