### PR TITLE
Remove unnecessary USART disable call during asynchronous serial basic transmitter construction

### DIFF
--- a/include/picolibrary/microchip/megaavr/asynchronous_serial.h
+++ b/include/picolibrary/microchip/megaavr/asynchronous_serial.h
@@ -90,8 +90,6 @@ class Basic_Transmitter {
         Clock_Configuration const &  clock_configuration ) noexcept :
         m_usart{ &usart }
     {
-        m_usart->disable();
-
         m_usart->configure_as_asynchronous_serial_usart(
             data_bits,
             parity,


### PR DESCRIPTION
Resolves #269 (Remove unnecessary USART disable call during asynchronous
serial basic transmitter construction).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
