### PR TITLE
Remove unnecessary SPI disable call during SPI peripheral based SPI basic controller construction

### DIFF
--- a/include/picolibrary/microchip/megaavr/spi.h
+++ b/include/picolibrary/microchip/megaavr/spi.h
@@ -103,8 +103,6 @@ class Basic_Controller<Peripheral::SPI> {
         m_codi{ Multiplexed_Signals::codi_port( spi ), Multiplexed_Signals::codi_mask( spi ) },
         m_spi{ &spi }
     {
-        m_spi->disable();
-
         m_spi->configure_as_spi_controller();
     }
 


### PR DESCRIPTION
Resolves #271 (Remove unnecessary SPI disable call during SPI peripheral
based SPI basic controller construction).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
