### PR TITLE
Remove unnecessary USART disable call during USART peripheral based SPI basic controller construction

### DIFF
--- a/include/picolibrary/microchip/megaavr/spi.h
+++ b/include/picolibrary/microchip/megaavr/spi.h
@@ -277,8 +277,6 @@ class Basic_Controller<Peripheral::USART> {
         m_xck{ Multiplexed_Signals::xck_port( usart ), Multiplexed_Signals::xck_mask( usart ) },
         m_usart{ &usart }
     {
-        m_usart->disable();
-
         m_usart->configure_as_spi_controller();
     }
 


### PR DESCRIPTION
Resolves #272 (Remove unnecessary USART disable call during USART
peripheral based SPI basic controller construction).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
