### PR TITLE
Treat multiplexed signals lookup errors as fatal errors

### DIFF
--- a/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega2560/spi.h
+++ b/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega2560/spi.h
@@ -25,6 +25,7 @@
 
 #include <cstdint>
 
+#include "picolibrary/fatal_error.h"
 #include "picolibrary/microchip/megaavr/peripheral/atmega2560.h"
 #include "picolibrary/microchip/megaavr/peripheral/port.h"
 #include "picolibrary/microchip/megaavr/peripheral/spi.h"
@@ -49,7 +50,7 @@ inline auto spi_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT
             return Peripheral::ATmega2560::PORTB::instance();
     } // switch
 
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    trap_fatal_error();
 }
 
 /**
@@ -85,7 +86,7 @@ inline auto ds_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast8
         case Peripheral::ATmega2560::SPI0::ADDRESS: return 0;
     } // switch
 
-    return 0;
+    trap_fatal_error();
 }
 
 /**
@@ -137,7 +138,7 @@ inline auto sck_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast
         case Peripheral::ATmega2560::SPI0::ADDRESS: return 1;
     } // switch
 
-    return 0;
+    trap_fatal_error();
 }
 
 /**
@@ -189,7 +190,7 @@ inline auto codi_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fas
         case Peripheral::ATmega2560::SPI0::ADDRESS: return 2;
     } // switch
 
-    return 0;
+    trap_fatal_error();
 }
 
 /**
@@ -241,7 +242,7 @@ inline auto cido_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fas
         case Peripheral::ATmega2560::SPI0::ADDRESS: return 3;
     } // switch
 
-    return 0;
+    trap_fatal_error();
 }
 
 /**

--- a/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega2560/twi.h
+++ b/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega2560/twi.h
@@ -25,6 +25,7 @@
 
 #include <cstdint>
 
+#include "picolibrary/fatal_error.h"
 #include "picolibrary/microchip/megaavr/peripheral/atmega2560.h"
 #include "picolibrary/microchip/megaavr/peripheral/port.h"
 #include "picolibrary/microchip/megaavr/peripheral/twi.h"
@@ -49,7 +50,7 @@ inline auto twi_port( Peripheral::TWI const & twi ) noexcept -> Peripheral::PORT
             return Peripheral::ATmega2560::PORTD::instance();
     } // switch
 
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    trap_fatal_error();
 }
 
 /**
@@ -85,7 +86,7 @@ inline auto scl_number( Peripheral::TWI const & twi ) noexcept -> std::uint_fast
         case Peripheral::ATmega2560::TWI0::ADDRESS: return 0;
     } // switch
 
-    return 0;
+    trap_fatal_error();
 }
 
 /**
@@ -137,7 +138,7 @@ inline auto sda_number( Peripheral::TWI const & twi ) noexcept -> std::uint_fast
         case Peripheral::ATmega2560::TWI0::ADDRESS: return 1;
     } // switch
 
-    return 0;
+    trap_fatal_error();
 }
 
 /**

--- a/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega2560/usart.h
+++ b/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega2560/usart.h
@@ -26,6 +26,7 @@
 
 #include <cstdint>
 
+#include "picolibrary/fatal_error.h"
 #include "picolibrary/microchip/megaavr/peripheral/atmega2560.h"
 #include "picolibrary/microchip/megaavr/peripheral/port.h"
 #include "picolibrary/microchip/megaavr/peripheral/usart.h"
@@ -56,7 +57,7 @@ inline auto usart_port( Peripheral::USART const & usart ) noexcept -> Peripheral
             return Peripheral::ATmega2560::PORTJ::instance();
     } // switch
 
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    trap_fatal_error();
 }
 
 /**
@@ -95,7 +96,7 @@ inline auto xck_number( Peripheral::USART const & usart ) noexcept -> std::uint_
         case Peripheral::ATmega2560::USART3::ADDRESS: return 2;
     } // switch
 
-    return 0;
+    trap_fatal_error();
 }
 
 /**
@@ -150,7 +151,7 @@ inline auto txd_number( Peripheral::USART const & usart ) noexcept -> std::uint_
         case Peripheral::ATmega2560::USART3::ADDRESS: return 1;
     } // switch
 
-    return 0;
+    trap_fatal_error();
 }
 
 /**
@@ -205,7 +206,7 @@ inline auto rxd_number( Peripheral::USART const & usart ) noexcept -> std::uint_
         case Peripheral::ATmega2560::USART3::ADDRESS: return 0;
     } // switch
 
-    return 0;
+    trap_fatal_error();
 }
 
 /**

--- a/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p/spi.h
+++ b/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p/spi.h
@@ -25,6 +25,7 @@
 
 #include <cstdint>
 
+#include "picolibrary/fatal_error.h"
 #include "picolibrary/microchip/megaavr/peripheral/atmega328p.h"
 #include "picolibrary/microchip/megaavr/peripheral/port.h"
 #include "picolibrary/microchip/megaavr/peripheral/spi.h"
@@ -49,7 +50,7 @@ inline auto spi_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT
             return Peripheral::ATmega328P::PORTB::instance();
     } // switch
 
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    trap_fatal_error();
 }
 
 /**
@@ -85,7 +86,7 @@ inline auto ds_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast8
         case Peripheral::ATmega328P::SPI0::ADDRESS: return 2;
     } // switch
 
-    return 0;
+    trap_fatal_error();
 }
 
 /**
@@ -137,7 +138,7 @@ inline auto sck_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast
         case Peripheral::ATmega328P::SPI0::ADDRESS: return 5;
     } // switch
 
-    return 0;
+    trap_fatal_error();
 }
 
 /**
@@ -189,7 +190,7 @@ inline auto codi_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fas
         case Peripheral::ATmega328P::SPI0::ADDRESS: return 3;
     } // switch
 
-    return 0;
+    trap_fatal_error();
 }
 
 /**
@@ -241,7 +242,7 @@ inline auto cido_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fas
         case Peripheral::ATmega328P::SPI0::ADDRESS: return 4;
     } // switch
 
-    return 0;
+    trap_fatal_error();
 }
 
 /**

--- a/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p/twi.h
+++ b/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p/twi.h
@@ -25,6 +25,7 @@
 
 #include <cstdint>
 
+#include "picolibrary/fatal_error.h"
 #include "picolibrary/microchip/megaavr/peripheral/atmega328p.h"
 #include "picolibrary/microchip/megaavr/peripheral/port.h"
 #include "picolibrary/microchip/megaavr/peripheral/twi.h"
@@ -49,7 +50,7 @@ inline auto twi_port( Peripheral::TWI const & twi ) noexcept -> Peripheral::PORT
             return Peripheral::ATmega328P::PORTC::instance();
     } // switch
 
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    trap_fatal_error();
 }
 
 /**
@@ -85,7 +86,7 @@ inline auto scl_number( Peripheral::TWI const & twi ) noexcept -> std::uint_fast
         case Peripheral::ATmega328P::TWI0::ADDRESS: return 5;
     } // switch
 
-    return 0;
+    trap_fatal_error();
 }
 
 /**
@@ -137,7 +138,7 @@ inline auto sda_number( Peripheral::TWI const & twi ) noexcept -> std::uint_fast
         case Peripheral::ATmega328P::TWI0::ADDRESS: return 4;
     } // switch
 
-    return 0;
+    trap_fatal_error();
 }
 
 /**

--- a/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p/usart.h
+++ b/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p/usart.h
@@ -26,6 +26,7 @@
 
 #include <cstdint>
 
+#include "picolibrary/fatal_error.h"
 #include "picolibrary/microchip/megaavr/peripheral/atmega328p.h"
 #include "picolibrary/microchip/megaavr/peripheral/port.h"
 #include "picolibrary/microchip/megaavr/peripheral/usart.h"
@@ -50,7 +51,7 @@ inline auto usart_port( Peripheral::USART const & usart ) noexcept -> Peripheral
             return Peripheral::ATmega328P::PORTD::instance();
     } // switch
 
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    trap_fatal_error();
 }
 
 /**
@@ -86,7 +87,7 @@ inline auto xck_number( Peripheral::USART const & usart ) noexcept -> std::uint_
         case Peripheral::ATmega328P::USART0::ADDRESS: return 4;
     } // switch
 
-    return 0;
+    trap_fatal_error();
 }
 
 /**
@@ -138,7 +139,7 @@ inline auto txd_number( Peripheral::USART const & usart ) noexcept -> std::uint_
         case Peripheral::ATmega328P::USART0::ADDRESS: return 1;
     } // switch
 
-    return 0;
+    trap_fatal_error();
 }
 
 /**
@@ -190,7 +191,7 @@ inline auto rxd_number( Peripheral::USART const & usart ) noexcept -> std::uint_
         case Peripheral::ATmega328P::USART0::ADDRESS: return 0;
     } // switch
 
-    return 0;
+    trap_fatal_error();
 }
 
 /**


### PR DESCRIPTION
Resolves #329 (Treat multiplexed signals lookup errors as fatal errors).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
