### PR TITLE
Add ATmega328/P peripherals namespace

### DIFF
--- a/include/picolibrary/microchip/megaavr/peripheral/atmega328p.h
+++ b/include/picolibrary/microchip/megaavr/peripheral/atmega328p.h
@@ -17,18 +17,28 @@
 
 /**
  * \file
- * \brief picolibrary::Microchip::megaAVR::Peripheral interface.
+ * \brief picolibrary::Microchip::megaAVR::Peripheral::ATmega328P interface.
  */
 
-#ifndef PICOLIBRARY_MICROCHIP_MEGAAVR_PERIPHERAL_H
-#define PICOLIBRARY_MICROCHIP_MEGAAVR_PERIPHERAL_H
-
-#include "picolibrary/microchip/megaavr/peripheral/atmega328p.h"
+#ifndef PICOLIBRARY_MICROCHIP_MEGAAVR_PERIPHERAL_ATMEGA328P_H
+#define PICOLIBRARY_MICROCHIP_MEGAAVR_PERIPHERAL_ATMEGA328P_H
 
 /**
- * \brief Microchip megaAVR peripheral facilities.
+ * \brief Microchip megaAVR ATmega328/P peripherals.
+ *
+ * \attention The contents of this namespace should not be used directly. Instead, set the
+ *            `-mmcu` compiler flag to `atmega328p` and use them through the
+ *            picolibrary::Microchip::megaAVR::Peripheral namespace.
  */
+namespace picolibrary::Microchip::megaAVR::Peripheral::ATmega328P {
+} // namespace picolibrary::Microchip::megaAVR::Peripheral::ATmega328P
+
 namespace picolibrary::Microchip::megaAVR::Peripheral {
+
+#ifdef __AVR_ATmega328P__
+using namespace ATmega328P;
+#endif // __AVR_ATmega328P__
+
 } // namespace picolibrary::Microchip::megaAVR::Peripheral
 
-#endif // PICOLIBRARY_MICROCHIP_MEGAAVR_PERIPHERAL_H
+#endif // PICOLIBRARY_MICROCHIP_MEGAAVR_PERIPHERAL_ATMEGA328P_H

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -26,6 +26,7 @@ set(
     PICOLIBRARY_MICROCHIP_MEGAAVR_SOURCE_FILES
     "picolibrary/microchip/megaavr.cc"
     "picolibrary/microchip/megaavr/peripheral.cc"
+    "picolibrary/microchip/megaavr/peripheral/atmega328p.cc"
     "picolibrary/microchip/megaavr/register.cc"
 )
 list(

--- a/source/picolibrary/microchip/megaavr/peripheral/atmega328p.cc
+++ b/source/picolibrary/microchip/megaavr/peripheral/atmega328p.cc
@@ -17,18 +17,7 @@
 
 /**
  * \file
- * \brief picolibrary::Microchip::megaAVR::Peripheral interface.
+ * \brief picolibrary::Microchip::megaAVR::Peripheral::ATmega328P implementation.
  */
-
-#ifndef PICOLIBRARY_MICROCHIP_MEGAAVR_PERIPHERAL_H
-#define PICOLIBRARY_MICROCHIP_MEGAAVR_PERIPHERAL_H
 
 #include "picolibrary/microchip/megaavr/peripheral/atmega328p.h"
-
-/**
- * \brief Microchip megaAVR peripheral facilities.
- */
-namespace picolibrary::Microchip::megaAVR::Peripheral {
-} // namespace picolibrary::Microchip::megaAVR::Peripheral
-
-#endif // PICOLIBRARY_MICROCHIP_MEGAAVR_PERIPHERAL_H


### PR DESCRIPTION
Resolves #362 (Add ATmega328/P peripherals namespace).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
