### PR TITLE
Add ATmega2560 peripherals namespace

### DIFF
--- a/include/picolibrary/microchip/megaavr/peripheral/atmega2560.h
+++ b/include/picolibrary/microchip/megaavr/peripheral/atmega2560.h
@@ -17,19 +17,28 @@
 
 /**
  * \file
- * \brief picolibrary::Microchip::megaAVR::Peripheral interface.
+ * \brief picolibrary::Microchip::megaAVR::Peripheral::ATmega2560 interface.
  */
 
-#ifndef PICOLIBRARY_MICROCHIP_MEGAAVR_PERIPHERAL_H
-#define PICOLIBRARY_MICROCHIP_MEGAAVR_PERIPHERAL_H
-
-#include "picolibrary/microchip/megaavr/peripheral/atmega2560.h"
-#include "picolibrary/microchip/megaavr/peripheral/atmega328p.h"
+#ifndef PICOLIBRARY_MICROCHIP_MEGAAVR_PERIPHERAL_ATMEGA2560_H
+#define PICOLIBRARY_MICROCHIP_MEGAAVR_PERIPHERAL_ATMEGA2560_H
 
 /**
- * \brief Microchip megaAVR peripheral facilities.
+ * \brief Microchip megaAVR ATmega2560 peripherals.
+ *
+ * \attention The contents of this namespace should not be used directly. Instead, set the
+ *            `-mmcu` compiler flag to `atmega2560` and use them through the
+ *            picolibrary::Microchip::megaAVR::Peripheral namespace.
  */
+namespace picolibrary::Microchip::megaAVR::Peripheral::ATmega2560 {
+} // namespace picolibrary::Microchip::megaAVR::Peripheral::ATmega2560
+
 namespace picolibrary::Microchip::megaAVR::Peripheral {
+
+#ifdef __AVR_ATmega2560__
+using namespace ATmega2560;
+#endif // __AVR_ATmega2560__
+
 } // namespace picolibrary::Microchip::megaAVR::Peripheral
 
-#endif // PICOLIBRARY_MICROCHIP_MEGAAVR_PERIPHERAL_H
+#endif // PICOLIBRARY_MICROCHIP_MEGAAVR_PERIPHERAL_ATMEGA2560_H

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -26,6 +26,7 @@ set(
     PICOLIBRARY_MICROCHIP_MEGAAVR_SOURCE_FILES
     "picolibrary/microchip/megaavr.cc"
     "picolibrary/microchip/megaavr/peripheral.cc"
+    "picolibrary/microchip/megaavr/peripheral/atmega2560.cc"
     "picolibrary/microchip/megaavr/peripheral/atmega328p.cc"
     "picolibrary/microchip/megaavr/register.cc"
 )

--- a/source/picolibrary/microchip/megaavr/peripheral/atmega2560.cc
+++ b/source/picolibrary/microchip/megaavr/peripheral/atmega2560.cc
@@ -17,19 +17,7 @@
 
 /**
  * \file
- * \brief picolibrary::Microchip::megaAVR::Peripheral interface.
+ * \brief picolibrary::Microchip::megaAVR::Peripheral::ATmega2560 implementation.
  */
-
-#ifndef PICOLIBRARY_MICROCHIP_MEGAAVR_PERIPHERAL_H
-#define PICOLIBRARY_MICROCHIP_MEGAAVR_PERIPHERAL_H
 
 #include "picolibrary/microchip/megaavr/peripheral/atmega2560.h"
-#include "picolibrary/microchip/megaavr/peripheral/atmega328p.h"
-
-/**
- * \brief Microchip megaAVR peripheral facilities.
- */
-namespace picolibrary::Microchip::megaAVR::Peripheral {
-} // namespace picolibrary::Microchip::megaAVR::Peripheral
-
-#endif // PICOLIBRARY_MICROCHIP_MEGAAVR_PERIPHERAL_H


### PR DESCRIPTION
Resolves #363 (Add ATmega2560 peripherals namespace).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
