### PR TITLE
Add ATmega328/P multiplexed signals facilities namespace

### DIFF
--- a/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p.h
+++ b/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p.h
@@ -17,18 +17,28 @@
 
 /**
  * \file
- * \brief picolibrary::Microchip::megaAVR::Multiplexed_Signals interface.
+ * \brief picolibrary::Microchip::megaAVR::Multiplexed_Signals::ATmega328P interface.
  */
 
-#ifndef PICOLIBRARY_MICROCHIP_MEGAAVR_MULTIPLEXED_SIGNALS_H
-#define PICOLIBRARY_MICROCHIP_MEGAAVR_MULTIPLEXED_SIGNALS_H
-
-#include "picolibrary/microchip/megaavr/multiplexed_signals/atmega328p.h"
+#ifndef PICOLIBRARY_MICROCHIP_MEGAAVR_MULTIPLEXED_SIGNALS_ATMEGA328P_H
+#define PICOLIBRARY_MICROCHIP_MEGAAVR_MULTIPLEXED_SIGNALS_ATMEGA328P_H
 
 /**
- * \brief Microchip megaAVR multiplexed signals facilities.
+ * \brief Microchip megaAVR ATmega328/P multiplexed signals facilities.
+ *
+ * \attention The contents of this namespace should not be used directly. Instead, set the
+ *            `-mmcu` compiler flag to `atmega328p` and use them through the
+ *            picolibrary::Microchip::megaAVR::Multiplexed_Signals namespace.
  */
+namespace picolibrary::Microchip::megaAVR::Multiplexed_Signals::ATmega328P {
+} // namespace picolibrary::Microchip::megaAVR::Multiplexed_Signals::ATmega328P
+
 namespace picolibrary::Microchip::megaAVR::Multiplexed_Signals {
+
+#ifdef __AVR_ATmega328P__
+using namespace ATmega328P;
+#endif // __AVR_ATmega328P__
+
 } // namespace picolibrary::Microchip::megaAVR::Multiplexed_Signals
 
-#endif // PICOLIBRARY_MICROCHIP_MEGAAVR_MULTIPLEXED_SIGNALS_H
+#endif // PICOLIBRARY_MICROCHIP_MEGAAVR_MULTIPLEXED_SIGNALS_ATMEGA328P_H

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -26,6 +26,7 @@ set(
     PICOLIBRARY_MICROCHIP_MEGAAVR_SOURCE_FILES
     "picolibrary/microchip/megaavr.cc"
     "picolibrary/microchip/megaavr/multiplexed_signals.cc"
+    "picolibrary/microchip/megaavr/multiplexed_signals/atmega328p.cc"
     "picolibrary/microchip/megaavr/peripheral.cc"
     "picolibrary/microchip/megaavr/peripheral/atmega2560.cc"
     "picolibrary/microchip/megaavr/peripheral/atmega328p.cc"

--- a/source/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p.cc
+++ b/source/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p.cc
@@ -17,18 +17,7 @@
 
 /**
  * \file
- * \brief picolibrary::Microchip::megaAVR::Multiplexed_Signals interface.
+ * \brief picolibrary::Microchip::megaAVR::Multiplexed_Signals::ATmega328P implementation.
  */
-
-#ifndef PICOLIBRARY_MICROCHIP_MEGAAVR_MULTIPLEXED_SIGNALS_H
-#define PICOLIBRARY_MICROCHIP_MEGAAVR_MULTIPLEXED_SIGNALS_H
 
 #include "picolibrary/microchip/megaavr/multiplexed_signals/atmega328p.h"
-
-/**
- * \brief Microchip megaAVR multiplexed signals facilities.
- */
-namespace picolibrary::Microchip::megaAVR::Multiplexed_Signals {
-} // namespace picolibrary::Microchip::megaAVR::Multiplexed_Signals
-
-#endif // PICOLIBRARY_MICROCHIP_MEGAAVR_MULTIPLEXED_SIGNALS_H


### PR DESCRIPTION
Resolves #368 (Add ATmega328/P multiplexed signals facilities
namespace).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
