### PR TITLE
Fix interactive testing log scope resolution operator usage inconsistencies

### DIFF
--- a/include/picolibrary/testing/interactive/microchip/megaavr/log.h
+++ b/include/picolibrary/testing/interactive/microchip/megaavr/log.h
@@ -102,7 +102,7 @@ class Log : public Output_Stream {
     static void initialize() noexcept
     {
         initialize(
-            picolibrary::Microchip::megaAVR::Peripheral::PICOLIBRARY_TESTING_INTERACTIVE_MICROCHIP_MEGAAVR_LOG_USART::instance(),
+            ::picolibrary::Microchip::megaAVR::Peripheral::PICOLIBRARY_TESTING_INTERACTIVE_MICROCHIP_MEGAAVR_LOG_USART::instance(),
             USART_Clock_Generator_Operating_Speed::PICOLIBRARY_TESTING_INTERACTIVE_MICROCHIP_MEGAAVR_LOG_USART_CLOCK_GENERATOR_OPERATING_SPEED,
             PICOLIBRARY_TESTING_INTERACTIVE_MICROCHIP_MEGAAVR_LOG_USART_CLOCK_GENERATOR_SCALING_FACTOR );
     }


### PR DESCRIPTION
Resolves #403 (Fix interactive testing log scope resolution operator
usage inconsistencies).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
