### PR TITLE
Fix GPIO internally pulled-up input pin initialization switch fall through

### DIFF
--- a/include/picolibrary/microchip/megaavr/gpio.h
+++ b/include/picolibrary/microchip/megaavr/gpio.h
@@ -117,8 +117,12 @@ class Internally_Pulled_Up_Input_Pin {
         configure_pin_as_internally_pulled_up_input();
 
         switch ( initial_pull_up_state ) {
-            case ::picolibrary::GPIO::Initial_Pull_Up_State::DISABLED: disable_pull_up();
-            case ::picolibrary::GPIO::Initial_Pull_Up_State::ENABLED: enable_pull_up();
+            case ::picolibrary::GPIO::Initial_Pull_Up_State::DISABLED:
+                disable_pull_up();
+                break;
+            case ::picolibrary::GPIO::Initial_Pull_Up_State::ENABLED:
+                enable_pull_up();
+                break;
         } // switch
     }
 


### PR DESCRIPTION
Resolves #422 (Fix GPIO internally pulled-up input pin initialization
switch fall through).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
