### PR TITLE
Add GPIO open-drain I/O pin toggle interactive test

### DIFF
--- a/configuration/testing-interactive-atmega2560-arduino-mega-2560/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega2560-arduino-mega-2560/CMakeLists.txt
@@ -70,3 +70,4 @@ mark_as_advanced(
 
 # configure interactive tests
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/gpio/internally_pulled_up_input_pin/state/CMakeLists.txt" )
+include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/CMakeLists.txt" )

--- a/configuration/testing-interactive-atmega2560-arduino-mega-2560/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega2560-arduino-mega-2560/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/CMakeLists.txt
@@ -1,0 +1,28 @@
+# picolibrary-microchip-megaavr
+#
+# Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the
+# picolibrary-microchip-megaavr contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# File: configuration/testing-interactive-atmega2560-arduino-mega-2560/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/CMakeLists.txt
+# Description: picolibrary-microchip-megaavr ATmega2560 Arduino Mega 2560
+#       picolibrary::Microchip::megaAVR::GPIO::Open_Drain_IO_Pin toggle interactive test
+#       configuration.
+
+set( PICOLIBRARY_MICROCHIP_MEGAAVR_GPIO_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST   ON       CACHE BOOL   "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MEGAAVR_GPIO_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_PIN_PORT "PORTB"  CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MEGAAVR_GPIO_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_PIN_MASK "1 << 6" CACHE STRING "" FORCE )
+mark_as_advanced(
+    PICOLIBRARY_MICROCHIP_MEGAAVR_GPIO_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST
+    PICOLIBRARY_MICROCHIP_MEGAAVR_GPIO_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_PIN_PORT
+    PICOLIBRARY_MICROCHIP_MEGAAVR_GPIO_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_PIN_MASK
+)

--- a/configuration/testing-interactive-atmega328p-adafruit-metro-mini/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega328p-adafruit-metro-mini/CMakeLists.txt
@@ -70,3 +70,4 @@ mark_as_advanced(
 
 # configure interactive tests
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/gpio/internally_pulled_up_input_pin/state/CMakeLists.txt" )
+include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/CMakeLists.txt" )

--- a/configuration/testing-interactive-atmega328p-adafruit-metro-mini/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega328p-adafruit-metro-mini/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/CMakeLists.txt
@@ -1,0 +1,28 @@
+# picolibrary-microchip-megaavr
+#
+# Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the
+# picolibrary-microchip-megaavr contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# File: configuration/testing-interactive-atmega328p-adafruit-metro-mini/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/CMakeLists.txt
+# Description: picolibrary-microchip-megaavr ATmega328/P Adafruit Metro Mini
+#       picolibrary::Microchip::megaAVR::GPIO::Open_Drain_IO_Pin toggle interactive test
+#       configuration.
+
+set( PICOLIBRARY_MICROCHIP_MEGAAVR_GPIO_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST   ON       CACHE BOOL   "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MEGAAVR_GPIO_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_PIN_PORT "PORTB"  CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MEGAAVR_GPIO_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_PIN_MASK "1 << 4" CACHE STRING "" FORCE )
+mark_as_advanced(
+    PICOLIBRARY_MICROCHIP_MEGAAVR_GPIO_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST
+    PICOLIBRARY_MICROCHIP_MEGAAVR_GPIO_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_PIN_PORT
+    PICOLIBRARY_MICROCHIP_MEGAAVR_GPIO_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_PIN_MASK
+)

--- a/configuration/testing-interactive-atmega328p-arduino-uno/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega328p-arduino-uno/CMakeLists.txt
@@ -70,3 +70,4 @@ mark_as_advanced(
 
 # configure interactive tests
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/gpio/internally_pulled_up_input_pin/state/CMakeLists.txt" )
+include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/CMakeLists.txt" )

--- a/configuration/testing-interactive-atmega328p-arduino-uno/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega328p-arduino-uno/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/CMakeLists.txt
@@ -1,0 +1,28 @@
+# picolibrary-microchip-megaavr
+#
+# Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the
+# picolibrary-microchip-megaavr contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# File: configuration/testing-interactive-atmega328p-arduino-uno/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/CMakeLists.txt
+# Description: picolibrary-microchip-megaavr ATmega328/P Arduino Uno
+#       picolibrary::Microchip::megaAVR::GPIO::Open_Drain_IO_Pin toggle interactive test
+#       configuration.
+
+set( PICOLIBRARY_MICROCHIP_MEGAAVR_GPIO_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST   ON       CACHE BOOL   "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MEGAAVR_GPIO_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_PIN_PORT "PORTB"  CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MEGAAVR_GPIO_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_PIN_MASK "1 << 4" CACHE STRING "" FORCE )
+mark_as_advanced(
+    PICOLIBRARY_MICROCHIP_MEGAAVR_GPIO_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST
+    PICOLIBRARY_MICROCHIP_MEGAAVR_GPIO_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_PIN_PORT
+    PICOLIBRARY_MICROCHIP_MEGAAVR_GPIO_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_PIN_MASK
+)

--- a/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/CMakeLists.txt
@@ -16,3 +16,7 @@
 # File: test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/CMakeLists.txt
 # Description: picolibrary::Microchip::megaAVR::GPIO::Open_Drain_IO_Pin interactive tests
 #       CMake rules.
+
+# build the picolibrary::Microchip::megaAVR::GPIO::Open_Drain_IO_Pin toggle interactive
+# test
+add_subdirectory( toggle )

--- a/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/CMakeLists.txt
@@ -1,0 +1,66 @@
+# picolibrary-microchip-megaavr
+#
+# Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the
+# picolibrary-microchip-megaavr contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# File: test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/CMakeLists.txt
+# Description: picolibrary::Microchip::megaAVR::GPIO::Open_Drain_IO_Pin toggle interactive
+#       test CMake rules.
+
+# build the picolibrary::Microchip::megaAVR::GPIO::Open_Drain_IO_Pin toggle interactive
+# test
+if( ${PICOLIBRARY_MICROCHIP_MEGAAVR_ENABLE_INTERACTIVE_TESTING} )
+    option(
+        PICOLIBRARY_MICROCHIP_MEGAAVR_GPIO_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST
+        "picolibrary-microchip-megaavr: enable the picolibrary::Microchip::megaAVR::GPIO::Open_Drain_IO_Pin toggle interactive test"
+        OFF
+    )
+
+    if( ${PICOLIBRARY_MICROCHIP_MEGAAVR_GPIO_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST} )
+        set(
+            PICOLIBRARY_MICROCHIP_MEGAAVR_GPIO_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_PIN_PORT
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr: picolibrary::Microchip::megaAVR::GPIO::Open_Drain_IO_Pin toggle interactive test pin PORT"
+        )
+        set(
+            PICOLIBRARY_MICROCHIP_MEGAAVR_GPIO_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_PIN_MASK
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr: picolibrary::Microchip::megaAVR::GPIO::Open_Drain_IO_Pin toggle interactive test pin mask"
+        )
+
+        add_executable(
+            test-interactive-picolibrary-microchip-megaavr-gpio-open_drain_io_pin-toggle
+            main.cc
+        )
+        target_compile_definitions(
+            test-interactive-picolibrary-microchip-megaavr-gpio-open_drain_io_pin-toggle
+            PRIVATE PIN_PORT=${PICOLIBRARY_MICROCHIP_MEGAAVR_GPIO_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_PIN_PORT}
+            PRIVATE PIN_MASK=${PICOLIBRARY_MICROCHIP_MEGAAVR_GPIO_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_PIN_MASK}
+        )
+        target_link_libraries(
+            test-interactive-picolibrary-microchip-megaavr-gpio-open_drain_io_pin-toggle
+            picolibrary
+            picolibrary-microchip-megaavr
+            picolibrary-microchip-megaavr-testing-interactive-fatal_error
+        )
+        add_avrdude_programming_targets(
+            test-interactive-picolibrary-microchip-megaavr-gpio-open_drain_io_pin-toggle
+            "${PICOLIBRARY_MICROCHIP_MEGAAVR_AVRDUDE_RESET}"
+            CONFIGURATION_FILE "${PICOLIBRARY_MICROCHIP_MEGAAVR_AVRDUDE_CONFIGURATION_FILE}"
+            PORT               "${PICOLIBRARY_MICROCHIP_MEGAAVR_AVRDUDE_PORT}"
+            PROGRAM_FLASH      "${PICOLIBRARY_MICROCHIP_MEGAAVR_AVRDUDE_PROGRAM_FLASH}"
+            VERBOSITY          "${PICOLIBRARY_MICROCHIP_MEGAAVR_AVRDUDE_VERBOSITY}"
+            VERIFY_FLASH       "${PICOLIBRARY_MICROCHIP_MEGAAVR_AVRDUDE_VERIFY_FLASH}"
+        )
+    endif( ${PICOLIBRARY_MICROCHIP_MEGAAVR_GPIO_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST} )
+endif( ${PICOLIBRARY_MICROCHIP_MEGAAVR_ENABLE_INTERACTIVE_TESTING} )

--- a/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/main.cc
@@ -40,7 +40,7 @@ using namespace ::picolibrary::Microchip::megaAVR::Peripheral;
 
 /**
  * \brief Execute the picolibrary::Microchip::megaAVR::GPIO::Open_Drain_IO_Pin toggle
- *        interactive test
+ *        interactive test.
  *
  * \return N/A
  */

--- a/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/main.cc
@@ -1,0 +1,56 @@
+/**
+ * picolibrary-microchip-megaavr
+ *
+ * Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the
+ * picolibrary-microchip-megaavr contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Microchip::megaAVR::GPIO::Open_Drain_IO_Pin toggle interactive test
+ *        program.
+ */
+
+#include <avr-libcpp/delay>
+
+#include "picolibrary/microchip/megaavr/gpio.h"
+#include "picolibrary/microchip/megaavr/peripheral.h"
+#include "picolibrary/testing/interactive/gpio.h"
+#include "picolibrary/testing/interactive/microchip/megaavr/log.h"
+
+namespace {
+
+using ::picolibrary::Microchip::megaAVR::GPIO::Open_Drain_IO_Pin;
+using ::picolibrary::Testing::Interactive::GPIO::toggle;
+using ::picolibrary::Testing::Interactive::Microchip::megaAVR::Log;
+
+using namespace ::picolibrary::Microchip::megaAVR::Peripheral;
+
+} // namespace
+
+/**
+ * \brief Execute the picolibrary::Microchip::megaAVR::GPIO::Open_Drain_IO_Pin toggle
+ *        interactive test
+ *
+ * \return N/A
+ */
+int main() noexcept
+{
+    Log::initialize();
+
+    toggle( Open_Drain_IO_Pin{ PIN_PORT::instance(), PIN_MASK }, []() {
+        avrlibcpp::delay_ms( 500 );
+    } );
+
+    for ( ;; ) {} // for
+}


### PR DESCRIPTION
Resolves #413 (Add GPIO open-drain I/O pin toggle interactive test).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
