### PR TITLE
Fix GPIO internally pulled-up input pin state interactive test comments

### DIFF
--- a/test/interactive/picolibrary/microchip/megaavr/gpio/internally_pulled_up_input_pin/state/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr/gpio/internally_pulled_up_input_pin/state/main.cc
@@ -41,7 +41,7 @@ using namespace ::picolibrary::Microchip::megaAVR::Peripheral;
 /**
  * \brief Execute the
  *        picolibrary::Microchip::megaAVR::GPIO::Internally_Pulled_Up_Input_Pin state
- *        interactive test
+ *        interactive test.
  *
  * \return N/A
  */


### PR DESCRIPTION
Resolves #430 (Fix GPIO internally pulled-up input pin state interactive
test comments).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
