### PR TITLE
Extract low level GPIO pin operations into a common utility class

### DIFF
--- a/include/picolibrary/microchip/megaavr/gpio.h
+++ b/include/picolibrary/microchip/megaavr/gpio.h
@@ -244,7 +244,7 @@ class Pin {
      */
     void toggle_push_pull_io() noexcept
     {
-        m_port->port ^= m_mask;
+        m_port->pin = m_mask;
     }
 
   private:

--- a/include/picolibrary/microchip/megaavr/gpio.h
+++ b/include/picolibrary/microchip/megaavr/gpio.h
@@ -24,6 +24,7 @@
 #define PICOLIBRARY_MICROCHIP_MEGAAVR_GPIO_H
 
 #include <cstdint>
+#include <utility>
 
 #include "picolibrary/gpio.h"
 #include "picolibrary/microchip/megaavr/peripheral/port.h"
@@ -34,14 +35,14 @@
 namespace picolibrary::Microchip::megaAVR::GPIO {
 
 /**
- * \brief Internally pulled-up input pin.
+ * \brief Pin.
  */
-class Internally_Pulled_Up_Input_Pin {
+class Pin {
   public:
     /**
      * \brief Constructor.
      */
-    constexpr Internally_Pulled_Up_Input_Pin() noexcept = default;
+    constexpr Pin() noexcept = default;
 
     /**
      * \brief Constructor.
@@ -49,7 +50,7 @@ class Internally_Pulled_Up_Input_Pin {
      * \param[in] port The GPIO port the pin is a member of.
      * \param[in] mask The mask identifying the pin.
      */
-    constexpr Internally_Pulled_Up_Input_Pin( Peripheral::PORT & port, std::uint8_t mask ) noexcept :
+    constexpr Pin( Peripheral::PORT & port, std::uint8_t mask ) noexcept :
         m_port{ &port },
         m_mask{ mask }
     {
@@ -60,7 +61,7 @@ class Internally_Pulled_Up_Input_Pin {
      *
      * \param[in] source The source of the move.
      */
-    constexpr Internally_Pulled_Up_Input_Pin( Internally_Pulled_Up_Input_Pin && source ) noexcept :
+    constexpr Pin( Pin && source ) noexcept :
         m_port{ source.m_port },
         m_mask{ source.m_mask }
     {
@@ -68,15 +69,12 @@ class Internally_Pulled_Up_Input_Pin {
         source.m_mask = 0;
     }
 
-    Internally_Pulled_Up_Input_Pin( Internally_Pulled_Up_Input_Pin const & ) = delete;
+    Pin( Pin const & ) = delete;
 
     /**
      * \brief Destructor.
      */
-    ~Internally_Pulled_Up_Input_Pin() noexcept
-    {
-        disable();
-    }
+    ~Pin() noexcept = default;
 
     /**
      * \brief Assignment operator.
@@ -85,11 +83,9 @@ class Internally_Pulled_Up_Input_Pin {
      *
      * \return The assigned to object.
      */
-    auto & operator=( Internally_Pulled_Up_Input_Pin && expression ) noexcept
+    constexpr auto & operator=( Pin && expression ) noexcept
     {
         if ( &expression != this ) {
-            disable();
-
             m_port = expression.m_port;
             m_mask = expression.m_mask;
 
@@ -100,33 +96,51 @@ class Internally_Pulled_Up_Input_Pin {
         return *this;
     }
 
-    auto operator=( Internally_Pulled_Up_Input_Pin const & ) = delete;
+    auto operator=( Pin const & ) = delete;
 
     /**
-     * \brief Initialize the pin's hardware.
+     * \brief Check if the pin is associated with a GPIO port.
      *
-     * \param[in] initial_pull_up_state The initial state of the pin's internal pull-up
-     *            resistor.
+     * \return true if the pin is associated with a GPIO port.
+     * \return false if the pin is not associated with a GPIO port.
      */
-    void initialize( ::picolibrary::GPIO::Initial_Pull_Up_State initial_pull_up_state = ::picolibrary::GPIO::Initial_Pull_Up_State::DISABLED ) noexcept
+    constexpr explicit operator bool() const noexcept
     {
-        configure_pin_as_internally_pulled_up_input();
-
-        switch ( initial_pull_up_state ) {
-            case ::picolibrary::GPIO::Initial_Pull_Up_State::DISABLED:
-                disable_pull_up();
-                break;
-            case ::picolibrary::GPIO::Initial_Pull_Up_State::ENABLED:
-                enable_pull_up();
-                break;
-        } // switch
+        return m_port;
     }
 
     /**
-     * \brief Check if the pin's internal pull-up resistor is disabled.
+     * \brief Configure the pin to act as an internally pulled-up input.
+     */
+    void configure_pin_as_internally_pulled_up_input() noexcept
+    {
+        m_port->ddr &= ~m_mask;
+    }
+
+    /**
+     * \brief Configure the pin to act as an open-drain I/O pin.
+     */
+    void configure_pin_as_open_drain_io() noexcept
+    {
+        m_port->port &= ~m_mask;
+    }
+
+    /**
+     * \brief Configure the pin to act as a push-pull I/O pin.
+     */
+    void configure_pin_as_push_pull_io() noexcept
+    {
+        m_port->ddr |= m_mask;
+    }
+
+    /**
+     * \brief Check if an internally pulled-up input pin's internal pull up resistor is
+     *        disabled.
      *
-     * \return true if the pin's internal pull-up resistor is disabled.
-     * \return false if the pin's internal pull-up resistor is not disabled.
+     * \return true if the internally pulled-up input pin's internal pull-up resistor is
+     *         disabled.
+     * \return false if the internally pulled-up input pin's internal pull-up resistor is
+     *         not disabled.
      */
     auto pull_up_is_disabled() const noexcept
     {
@@ -134,10 +148,13 @@ class Internally_Pulled_Up_Input_Pin {
     }
 
     /**
-     * \brief Check if the pin's internal pull-up resistor is enabled.
+     * \brief Check if an internally pulled-up input pin's internal pull up resistor is
+     *        enabled.
      *
-     * \return true if the pin's internal pull-up resistor is enabled.
-     * \return false if the pin's internal pull-up resistor is not enabled.
+     * \return true if the internally pulled-up input pin's internal pull-up resistor is
+     *         enabled.
+     * \return false if the internally pulled-up input pin's internal pull-up resistor is
+     *         not enabled.
      */
     auto pull_up_is_enabled() const noexcept -> bool
     {
@@ -145,7 +162,7 @@ class Internally_Pulled_Up_Input_Pin {
     }
 
     /**
-     * \brief Disable the pin's internal pull-up resistor.
+     * \brief Disable an internally pulled-up input pin's internal pull-up resistor.
      */
     void disable_pull_up() noexcept
     {
@@ -153,7 +170,7 @@ class Internally_Pulled_Up_Input_Pin {
     }
 
     /**
-     * \brief Enable the pin's internal pull-up resistor.
+     * \brief Enable an internally pulled-up input pin's internal pull-up resistor.
      */
     void enable_pull_up() noexcept
     {
@@ -182,6 +199,54 @@ class Internally_Pulled_Up_Input_Pin {
         return m_port->pin & m_mask;
     }
 
+    /**
+     * \brief Transition an open-drain I/O pin to the low state.
+     */
+    void transition_open_drain_io_to_low() noexcept
+    {
+        m_port->ddr |= m_mask;
+    }
+
+    /**
+     * \brief Transition a push-pull I/O pin to the low state.
+     */
+    void transition_push_pull_io_to_low() noexcept
+    {
+        m_port->port &= ~m_mask;
+    }
+
+    /**
+     * \brief Transition an open-drain I/O pin to the high state.
+     */
+    void transition_open_drain_io_to_high() noexcept
+    {
+        m_port->ddr &= ~m_mask;
+    }
+
+    /**
+     * \brief Transition a push-pull I/O pin to the high state.
+     */
+    void transition_push_pull_io_to_high() noexcept
+    {
+        m_port->port |= m_mask;
+    }
+
+    /**
+     * \brief Toggle the state of an open-drain I/O pin.
+     */
+    void toggle_open_drain_io() noexcept
+    {
+        m_port->ddr ^= m_mask;
+    }
+
+    /**
+     * \brief Toggle the state of a push-pull I/O pin.
+     */
+    void toggle_push_pull_io() noexcept
+    {
+        m_port->port ^= m_mask;
+    }
+
   private:
     /**
      * \brief The GPIO port the pin is a member of.
@@ -192,22 +257,159 @@ class Internally_Pulled_Up_Input_Pin {
      * \brief The mask identifying the pin.
      */
     std::uint8_t m_mask{};
+};
+
+/**
+ * \brief Internally pulled-up input pin.
+ */
+class Internally_Pulled_Up_Input_Pin {
+  public:
+    /**
+     * \brief Constructor.
+     */
+    constexpr Internally_Pulled_Up_Input_Pin() noexcept = default;
 
     /**
-     * \brief Configure the pin to act as an internally pulled-up input.
+     * \brief Constructor.
+     *
+     * \param[in] port The GPIO port the pin is a member of.
+     * \param[in] mask The mask identifying the pin.
      */
-    void configure_pin_as_internally_pulled_up_input() noexcept
+    constexpr Internally_Pulled_Up_Input_Pin( Peripheral::PORT & port, std::uint8_t mask ) noexcept :
+        m_pin{ port, mask }
     {
-        m_port->ddr &= ~m_mask;
     }
+
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] source The source of the move.
+     */
+    constexpr Internally_Pulled_Up_Input_Pin( Internally_Pulled_Up_Input_Pin && source ) noexcept = default;
+
+    Internally_Pulled_Up_Input_Pin( Internally_Pulled_Up_Input_Pin const & ) = delete;
+
+    /**
+     * \brief Destructor.
+     */
+    ~Internally_Pulled_Up_Input_Pin() noexcept
+    {
+        disable();
+    }
+
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    constexpr auto & operator=( Internally_Pulled_Up_Input_Pin && expression ) noexcept
+    {
+        if ( &expression != this ) {
+            disable();
+
+            m_pin = std::move( expression.m_pin );
+        } // if
+
+        return *this;
+    }
+
+    auto operator=( Internally_Pulled_Up_Input_Pin const & ) = delete;
+
+    /**
+     * \brief Initialize the pin's hardware.
+     *
+     * \param[in] initial_pull_up_state The initial state of the pin's internal pull-up
+     *            resistor.
+     */
+    void initialize( ::picolibrary::GPIO::Initial_Pull_Up_State initial_pull_up_state = ::picolibrary::GPIO::Initial_Pull_Up_State::DISABLED ) noexcept
+    {
+        m_pin.configure_pin_as_internally_pulled_up_input();
+
+        switch ( initial_pull_up_state ) {
+            case ::picolibrary::GPIO::Initial_Pull_Up_State::DISABLED:
+                m_pin.disable_pull_up();
+                break;
+            case ::picolibrary::GPIO::Initial_Pull_Up_State::ENABLED:
+                m_pin.enable_pull_up();
+                break;
+        } // switch
+    }
+
+    /**
+     * \brief Check if the pin's internal pull-up resistor is disabled.
+     *
+     * \return true if the pin's internal pull-up resistor is disabled.
+     * \return false if the pin's internal pull-up resistor is not disabled.
+     */
+    auto pull_up_is_disabled() const noexcept
+    {
+        return m_pin.pull_up_is_disabled();
+    }
+
+    /**
+     * \brief Check if the pin's internal pull-up resistor is enabled.
+     *
+     * \return true if the pin's internal pull-up resistor is enabled.
+     * \return false if the pin's internal pull-up resistor is not enabled.
+     */
+    auto pull_up_is_enabled() const noexcept
+    {
+        return m_pin.pull_up_is_enabled();
+    }
+
+    /**
+     * \brief Disable the pin's internal pull-up resistor.
+     */
+    void disable_pull_up() noexcept
+    {
+        m_pin.disable_pull_up();
+    }
+
+    /**
+     * \brief Enable the pin's internal pull-up resistor.
+     */
+    void enable_pull_up() noexcept
+    {
+        m_pin.enable_pull_up();
+    }
+
+    /**
+     * \brief Check if the pin is in the low state.
+     *
+     * \return true if the pin is in the low state.
+     * \return false if the pin is not in the low state.
+     */
+    auto is_low() const noexcept
+    {
+        return m_pin.is_low();
+    }
+
+    /**
+     * \brief Check if the pin is in the high state.
+     *
+     * \return true if the pin is in the high state.
+     * \return false if the pin is not in the high state.
+     */
+    auto is_high() const noexcept
+    {
+        return m_pin.is_high();
+    }
+
+  private:
+    /**
+     * \brief The pin.
+     */
+    Pin m_pin{};
 
     /**
      * \brief Disable the pin.
      */
-    void disable() noexcept
+    constexpr void disable() noexcept
     {
-        if ( m_port ) {
-            disable_pull_up();
+        if ( m_pin ) {
+            m_pin.disable_pull_up();
         } // if
     }
 };
@@ -229,8 +431,7 @@ class Open_Drain_IO_Pin {
      * \param[in] mask The mask identifying the pin.
      */
     constexpr Open_Drain_IO_Pin( Peripheral::PORT & port, std::uint8_t mask ) noexcept :
-        m_port{ &port },
-        m_mask{ mask }
+        m_pin{ port, mask }
     {
     }
 
@@ -239,13 +440,7 @@ class Open_Drain_IO_Pin {
      *
      * \param[in] source The source of the move.
      */
-    constexpr Open_Drain_IO_Pin( Open_Drain_IO_Pin && source ) noexcept :
-        m_port{ source.m_port },
-        m_mask{ source.m_mask }
-    {
-        source.m_port = nullptr;
-        source.m_mask = 0;
-    }
+    constexpr Open_Drain_IO_Pin( Open_Drain_IO_Pin && source ) noexcept = default;
 
     Open_Drain_IO_Pin( Open_Drain_IO_Pin const & ) = delete;
 
@@ -264,16 +459,12 @@ class Open_Drain_IO_Pin {
      *
      * \return The assigned to object.
      */
-    auto & operator=( Open_Drain_IO_Pin && expression ) noexcept
+    constexpr auto & operator=( Open_Drain_IO_Pin && expression ) noexcept
     {
         if ( &expression != this ) {
             disable();
 
-            m_port = expression.m_port;
-            m_mask = expression.m_mask;
-
-            expression.m_port = nullptr;
-            expression.m_mask = 0;
+            m_pin = std::move( expression.m_pin );
         } // if
 
         return *this;
@@ -288,12 +479,14 @@ class Open_Drain_IO_Pin {
      */
     void initialize( ::picolibrary::GPIO::Initial_Pin_State initial_pin_state = ::picolibrary::GPIO::Initial_Pin_State::LOW ) noexcept
     {
-        configure_pin_as_open_drain_io();
+        m_pin.configure_pin_as_open_drain_io();
 
         switch ( initial_pin_state ) {
-            case ::picolibrary::GPIO::Initial_Pin_State::LOW: transition_to_low(); break;
+            case ::picolibrary::GPIO::Initial_Pin_State::LOW:
+                m_pin.transition_open_drain_io_to_low();
+                break;
             case ::picolibrary::GPIO::Initial_Pin_State::HIGH:
-                transition_to_high();
+                m_pin.transition_open_drain_io_to_high();
                 break;
         } // switch
     }
@@ -306,7 +499,7 @@ class Open_Drain_IO_Pin {
      */
     auto is_low() const noexcept
     {
-        return not is_high();
+        return m_pin.is_low();
     }
 
     /**
@@ -315,9 +508,9 @@ class Open_Drain_IO_Pin {
      * \return true if the pin is in the high state.
      * \return false if the pin is not in the high state.
      */
-    auto is_high() const noexcept -> bool
+    auto is_high() const noexcept
     {
-        return m_port->pin & m_mask;
+        return m_pin.is_high();
     }
 
     /**
@@ -325,7 +518,7 @@ class Open_Drain_IO_Pin {
      */
     void transition_to_low() noexcept
     {
-        m_port->ddr |= m_mask;
+        m_pin.transition_open_drain_io_to_low();
     }
 
     /**
@@ -333,7 +526,7 @@ class Open_Drain_IO_Pin {
      */
     void transition_to_high() noexcept
     {
-        m_port->ddr &= ~m_mask;
+        m_pin.transition_open_drain_io_to_high();
     }
 
     /**
@@ -341,43 +534,22 @@ class Open_Drain_IO_Pin {
      */
     void toggle() noexcept
     {
-        m_port->ddr ^= m_mask;
+        m_pin.toggle_open_drain_io();
     }
 
   private:
     /**
-     * \brief The GPIO port the pin is a member of.
+     * \brief The pin.
      */
-    Peripheral::PORT * m_port{};
-
-    /**
-     * \brief The mask identifying the pin.
-     */
-    std::uint8_t m_mask{};
-
-    /**
-     * \brief Configure the pin to act as an internally pulled-up input.
-     */
-    void configure_pin_as_internally_pulled_up_input() noexcept
-    {
-        m_port->ddr &= ~m_mask;
-    }
-
-    /**
-     * \brief Configure the pin to act as an open-drain I/O pin.
-     */
-    void configure_pin_as_open_drain_io() noexcept
-    {
-        m_port->port &= ~m_mask;
-    }
+    Pin m_pin{};
 
     /**
      * \brief Disable the pin.
      */
-    void disable() noexcept
+    constexpr void disable() noexcept
     {
-        if ( m_port ) {
-            configure_pin_as_internally_pulled_up_input();
+        if ( m_pin ) {
+            m_pin.configure_pin_as_internally_pulled_up_input();
         } // if
     }
 };
@@ -399,8 +571,7 @@ class Push_Pull_IO_Pin {
      * \param[in] mask The mask identifying the pin.
      */
     constexpr Push_Pull_IO_Pin( Peripheral::PORT & port, std::uint8_t mask ) noexcept :
-        m_port{ &port },
-        m_mask{ mask }
+        m_pin{ port, mask }
     {
     }
 
@@ -409,13 +580,7 @@ class Push_Pull_IO_Pin {
      *
      * \param[in] source The source of the move.
      */
-    constexpr Push_Pull_IO_Pin( Push_Pull_IO_Pin && source ) noexcept :
-        m_port{ source.m_port },
-        m_mask{ source.m_mask }
-    {
-        source.m_port = nullptr;
-        source.m_mask = 0;
-    }
+    constexpr Push_Pull_IO_Pin( Push_Pull_IO_Pin && source ) noexcept = default;
 
     Push_Pull_IO_Pin( Push_Pull_IO_Pin const & ) = delete;
 
@@ -434,16 +599,12 @@ class Push_Pull_IO_Pin {
      *
      * \return The assigned to object.
      */
-    auto & operator=( Push_Pull_IO_Pin && expression ) noexcept
+    constexpr auto & operator=( Push_Pull_IO_Pin && expression ) noexcept
     {
         if ( &expression != this ) {
             disable();
 
-            m_port = expression.m_port;
-            m_mask = expression.m_mask;
-
-            expression.m_port = nullptr;
-            expression.m_mask = 0;
+            m_pin = std::move( expression.m_pin );
         } // if
 
         return *this;
@@ -459,13 +620,15 @@ class Push_Pull_IO_Pin {
     void initialize( ::picolibrary::GPIO::Initial_Pin_State initial_pin_state = ::picolibrary::GPIO::Initial_Pin_State::LOW ) noexcept
     {
         switch ( initial_pin_state ) {
-            case ::picolibrary::GPIO::Initial_Pin_State::LOW: transition_to_low(); break;
+            case ::picolibrary::GPIO::Initial_Pin_State::LOW:
+                m_pin.transition_push_pull_io_to_low();
+                break;
             case ::picolibrary::GPIO::Initial_Pin_State::HIGH:
-                transition_to_high();
+                m_pin.transition_push_pull_io_to_high();
                 break;
         } // switch
 
-        configure_pin_as_push_pull_io();
+        m_pin.configure_pin_as_push_pull_io();
     }
 
     /**
@@ -476,7 +639,7 @@ class Push_Pull_IO_Pin {
      */
     auto is_low() const noexcept
     {
-        return not is_high();
+        return m_pin.is_low();
     }
 
     /**
@@ -485,9 +648,9 @@ class Push_Pull_IO_Pin {
      * \return true if the pin is in the high state.
      * \return false if the pin is not in the high state.
      */
-    auto is_high() const noexcept -> bool
+    auto is_high() const noexcept
     {
-        return m_port->pin & m_mask;
+        return m_pin.is_high();
     }
 
     /**
@@ -495,7 +658,7 @@ class Push_Pull_IO_Pin {
      */
     void transition_to_low() noexcept
     {
-        m_port->port &= ~m_mask;
+        m_pin.transition_push_pull_io_to_low();
     }
 
     /**
@@ -503,7 +666,7 @@ class Push_Pull_IO_Pin {
      */
     void transition_to_high() noexcept
     {
-        m_port->port |= m_mask;
+        m_pin.transition_push_pull_io_to_high();
     }
 
     /**
@@ -511,52 +674,23 @@ class Push_Pull_IO_Pin {
      */
     void toggle() noexcept
     {
-        m_port->port ^= m_mask;
+        m_pin.toggle_push_pull_io();
     }
 
   private:
     /**
-     * \brief The GPIO port the pin is a member of.
+     * \brief The pin.
      */
-    Peripheral::PORT * m_port{};
-
-    /**
-     * \brief The mask identifying the pin.
-     */
-    std::uint8_t m_mask{};
-
-    /**
-     * \brief Configure the pin to act as an internally pulled-up input.
-     */
-    void configure_pin_as_internally_pulled_up_input() noexcept
-    {
-        m_port->ddr &= ~m_mask;
-    }
-
-    /**
-     * \brief Configure the pin to act as an push-pull I/O pin.
-     */
-    void configure_pin_as_push_pull_io() noexcept
-    {
-        m_port->ddr |= m_mask;
-    }
-
-    /**
-     * \brief Disable the pin's internal pull-up resistor.
-     */
-    void disable_pull_up() noexcept
-    {
-        m_port->port &= ~m_mask;
-    }
+    Pin m_pin{};
 
     /**
      * \brief Disable the pin.
      */
     void disable() noexcept
     {
-        if ( m_port ) {
-            configure_pin_as_internally_pulled_up_input();
-            disable_pull_up();
+        if ( m_pin ) {
+            m_pin.configure_pin_as_internally_pulled_up_input();
+            m_pin.disable_pull_up();
         } // if
     }
 };


### PR DESCRIPTION
Resolves #441 (Extract low level GPIO pin operations into a common
utility class).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
