### PR TITLE
Fix potential erroneous multiplexed signals lookup function compilation errors

### DIFF
--- a/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega2560/usart.h
+++ b/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega2560/usart.h
@@ -60,6 +60,8 @@ constexpr auto usart_port_address( std::uintptr_t usart_address ) noexcept -> st
     } // switch
 
     expect( false, Generic_Error::INVALID_ARGUMENT );
+
+    return 0; // unreachable
 }
 
 /**
@@ -134,6 +136,8 @@ constexpr auto xck_number( std::uintptr_t usart_address ) noexcept -> std::uint_
     } // switch
 
     expect( false, Generic_Error::INVALID_ARGUMENT );
+
+    return 0; // unreachable
 }
 
 /**
@@ -240,6 +244,8 @@ constexpr auto txd_number( std::uintptr_t usart_address ) noexcept -> std::uint_
     } // switch
 
     expect( false, Generic_Error::INVALID_ARGUMENT );
+
+    return 0; // unreachable
 }
 
 /**
@@ -346,6 +352,8 @@ constexpr auto rxd_number( std::uintptr_t usart_address ) noexcept -> std::uint_
     } // switch
 
     expect( false, Generic_Error::INVALID_ARGUMENT );
+
+    return 0; // unreachable
 }
 
 /**

--- a/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p/usart.h
+++ b/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p/usart.h
@@ -54,6 +54,8 @@ constexpr auto usart_port_address( std::uintptr_t usart_address ) noexcept -> st
     } // switch
 
     expect( false, Generic_Error::INVALID_ARGUMENT );
+
+    return 0; // unreachable
 }
 
 /**
@@ -125,6 +127,8 @@ constexpr auto xck_number( std::uintptr_t usart_address ) noexcept -> std::uint_
     } // switch
 
     expect( false, Generic_Error::INVALID_ARGUMENT );
+
+    return 0; // unreachable
 }
 
 /**
@@ -228,6 +232,8 @@ constexpr auto txd_number( std::uintptr_t usart_address ) noexcept -> std::uint_
     } // switch
 
     expect( false, Generic_Error::INVALID_ARGUMENT );
+
+    return 0; // unreachable
 }
 
 /**
@@ -331,6 +337,8 @@ constexpr auto rxd_number( std::uintptr_t usart_address ) noexcept -> std::uint_
     } // switch
 
     expect( false, Generic_Error::INVALID_ARGUMENT );
+
+    return 0; // unreachable
 }
 
 /**


### PR DESCRIPTION
Resolves #443 (Fix potential erroneous multiplexed signals lookup
function compilation errors).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
