### PR TITLE
Add Microchip megaAVR asynchronous serial facilities interactive testing skeleton

### DIFF
--- a/test/interactive/picolibrary/microchip/megaavr/asynchronous_serial/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/megaavr/asynchronous_serial/CMakeLists.txt
@@ -13,11 +13,6 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# File: test/interactive/picolibrary/microchip/megaavr/CMakeLists.txt
-# Description: picolibrary::Microchip::megaAVR interactive tests CMake rules.
-
-# build the picolibrary::Microchip::megaAVR::Asynchronous_Serial interactive tests
-add_subdirectory( asynchronous_serial )
-
-# build the picolibrary::Microchip::megaAVR::GPIO interactive tests
-add_subdirectory( gpio )
+# File: test/interactive/picolibrary/microchip/megaavr/asynchronous_serial/CMakeLists.txt
+# Description: picolibrary::Microchip::megaAVR::Asynchronous_Serial interactive tests
+#       CMake rules.


### PR DESCRIPTION
Resolves #452 (Add Microchip megaAVR asynchronous serial facilities
interactive testing skeleton).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
