### PR TITLE
Add Microchip megaAVR asynchronous serial USART parity configuration

### DIFF
--- a/include/picolibrary/microchip/megaavr/asynchronous_serial.h
+++ b/include/picolibrary/microchip/megaavr/asynchronous_serial.h
@@ -53,6 +53,15 @@ enum class USART_Data_Bits : std::uint_fast8_t {
          | ( 0b11 << Peripheral::USART::Normal::UCSRC::Bit::UCSZ ), ///< 9.
 };
 
+/**
+ * \brief USART parity configuration.
+ */
+enum class USART_Parity : std::uint8_t {
+    NONE = 0b00 << Peripheral::USART::Normal::UCSRC::Bit::UPM, ///< None.
+    EVEN = 0b10 << Peripheral::USART::Normal::UCSRC::Bit::UPM, ///< Even.
+    ODD  = 0b11 << Peripheral::USART::Normal::UCSRC::Bit::UPM, ///< Odd.
+};
+
 } // namespace picolibrary::Microchip::megaAVR::Asynchronous_Serial
 
 #endif // PICOLIBRARY_MICROCHIP_MEGAAVR_ASYNCHRONOUS_SERIAL_H


### PR DESCRIPTION
Resolves #455 (Add Microchip megaAVR asynchronous serial USART parity
configuration).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
