### PR TITLE
Add Microchip megaAVR asynchronous serial USART clock generator operating speed configuration

### DIFF
--- a/include/picolibrary/microchip/megaavr/asynchronous_serial.h
+++ b/include/picolibrary/microchip/megaavr/asynchronous_serial.h
@@ -70,6 +70,14 @@ enum class USART_Stop_Bits : std::uint8_t {
     _2 = Peripheral::USART::Normal::UCSRC::USBS_2_BIT, ///< 2.
 };
 
+/**
+ * \brief USART clock generator operating speed.
+ */
+enum class USART_Clock_Generator_Operating_Speed : std::uint8_t {
+    NORMAL = 0b0 << Peripheral::USART::Normal::UCSRA::Bit::U2X, ///< Normal.
+    DOUBLE = 0b1 << Peripheral::USART::Normal::UCSRA::Bit::U2X, ///< Double.
+};
+
 } // namespace picolibrary::Microchip::megaAVR::Asynchronous_Serial
 
 #endif // PICOLIBRARY_MICROCHIP_MEGAAVR_ASYNCHRONOUS_SERIAL_H


### PR DESCRIPTION
Resolves #456 (Add Microchip megaAVR asynchronous serial USART clock
generator operating speed configuration).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
