### PR TITLE
Add Microchip megaAVR asynchronous serial transmitter interactive testing skeleton

### DIFF
--- a/test/interactive/picolibrary/microchip/megaavr/asynchronous_serial/transmitter/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/megaavr/asynchronous_serial/transmitter/CMakeLists.txt
@@ -13,10 +13,6 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# File: test/interactive/picolibrary/microchip/megaavr/asynchronous_serial/CMakeLists.txt
-# Description: picolibrary::Microchip::megaAVR::Asynchronous_Serial interactive tests
-#       CMake rules.
-
-# build the picolibrary::Microchip::megaAVR::Asynchronous_Serial::Transmitter interactive
-# tests
-add_subdirectory( transmitter )
+# File: test/interactive/picolibrary/microchip/megaavr/asynchronous_serial/transmitter/CMakeLists.txt
+# Description: picolibrary::Microchip::megaAVR::Asynchronous_Serial::Transmitter
+#       interactive tests CMake rules.


### PR DESCRIPTION
Resolves #459 (Add Microchip megaAVR asynchronous serial transmitter
interactive testing skeleton).

Resolves #.

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
