### PR TITLE
Make Microchip megaAVR asynchronous serial basic transmitter move assignment constexpr capable

### DIFF
--- a/include/picolibrary/microchip/megaavr/asynchronous_serial.h
+++ b/include/picolibrary/microchip/megaavr/asynchronous_serial.h
@@ -154,7 +154,7 @@ class Basic_Transmitter {
      *
      * \return The assigned to object.
      */
-    auto & operator=( Basic_Transmitter && expression ) noexcept
+    constexpr auto & operator=( Basic_Transmitter && expression ) noexcept
     {
         if ( &expression != this ) {
             disable();
@@ -198,7 +198,7 @@ class Basic_Transmitter {
     /**
      * \brief Disable the transmitter.
      */
-    void disable() noexcept
+    constexpr void disable() noexcept
     {
         if ( m_usart ) {
             disable_transmitter();


### PR DESCRIPTION
Resolves #474 (Make Microchip megaAVR asynchronous serial basic
transmitter move assignment constexpr capable).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
