### PR TITLE
Fix Microchip megaAVR I2C basic controller read overloading

### DIFF
--- a/include/picolibrary/microchip/megaavr/i2c.h
+++ b/include/picolibrary/microchip/megaavr/i2c.h
@@ -245,9 +245,9 @@ class Basic_Controller {
 
         switch ( status() ) {
             case Peripheral::TWI::TWSR::TWS::TWS_CONTROLLER_DATA_RECEIVED_ACK_TRANSMITTED:
-                return read();
+                return finish_read();
             case Peripheral::TWI::TWSR::TWS::TWS_CONTROLLER_DATA_RECEIVED_NACK_TRANSMITTED:
-                return read();
+                return finish_read();
             case Peripheral::TWI::TWSR::TWS::TWS_BUS_ERROR:
                 ensure( false, Generic_Error::BUS_ERROR );
                 break;
@@ -408,11 +408,11 @@ class Basic_Controller {
     }
 
     /**
-     * \brief Read received data.
+     * \brief Finish a read by reading the received data.
      *
      * \return The received data.
      */
-    auto read() const noexcept -> std::uint8_t
+    auto finish_read() const noexcept -> std::uint8_t
     {
         return m_twi->twdr;
     }


### PR DESCRIPTION
Resolves #505 (Fix Microchip megaAVR I2C basic controller read
overloading).

Having a private overload of the read() function caused a compilation
error when the basic controller's read() function was introduced into
the controller's class definition.

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
