### PR TITLE
Fix Microchip megaAVR I2C basic controller stop condition transmission

### DIFF
--- a/include/picolibrary/microchip/megaavr/i2c.h
+++ b/include/picolibrary/microchip/megaavr/i2c.h
@@ -182,7 +182,9 @@ class Basic_Controller {
      */
     void stop() noexcept
     {
-        transmit_stop();
+        initiate_stop_transmission();
+
+        while ( not stop_transmission_complete() ) {} // while
     }
 
     /**
@@ -386,12 +388,23 @@ class Basic_Controller {
     }
 
     /**
-     * \brief Transmit a stop condition.
+     * \brief Initiate transmission of a stop condition.
      */
-    void transmit_stop() noexcept
+    void initiate_stop_transmission() noexcept
     {
         m_twi->twcr = Peripheral::TWI::TWCR::Mask::TWINT | Peripheral::TWI::TWCR::Mask::TWSTO
                       | Peripheral::TWI::TWCR::Mask::TWEN;
+    }
+
+    /**
+     * \brief Check if transmission of a stop condition has been completed.
+     *
+     * \return true if transmission of the stop condition has been completed.
+     * \return false if transmission of the stop condition has not been completed.
+     */
+    auto stop_transmission_complete() const noexcept -> bool
+    {
+        return not( m_twi->twcr & Peripheral::TWI::TWCR::Mask::TWSTO );
     }
 
     /**


### PR DESCRIPTION
Resolves #510 (Fix Microchip megaAVR I2C basic controller stop condition
transmission).

The previous implementation did not wait for stop condition transmission
to complete which could lead to a start condition transmission failure.

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
