### PR TITLE
Add Microchip megaAVR SPI SPI bit order

### DIFF
--- a/include/picolibrary/microchip/megaavr/spi.h
+++ b/include/picolibrary/microchip/megaavr/spi.h
@@ -73,6 +73,14 @@ enum class SPI_Clock_Phase : std::uint8_t {
     CAPTURE_ACTIVE_TO_IDLE = Peripheral::SPI::SPCR::CPHA_LEADING_EDGE_SETUP_TRAILING_EDGE_SAMPLE, ///< Capture data on the active-to-idle clock transition.
 };
 
+/**
+ * \brief SPI bit order.
+ */
+enum class SPI_Bit_Order : std::uint8_t {
+    MSB_FIRST = 0b0 << Peripheral::SPI::SPCR::Bit::DORD, ///< MSB first.
+    LSB_FIRST = 0b1 << Peripheral::SPI::SPCR::Bit::DORD, ///< LSB first.
+};
+
 } // namespace picolibrary::Microchip::megaAVR::SPI
 
 #endif // PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_H


### PR DESCRIPTION
Resolves #527 (Add Microchip megaAVR SPI SPI bit order).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
