### PR TITLE
Add Microchip megaAVR SPI USART clock polarity

### DIFF
--- a/include/picolibrary/microchip/megaavr/spi.h
+++ b/include/picolibrary/microchip/megaavr/spi.h
@@ -26,6 +26,7 @@
 #include <cstdint>
 
 #include "picolibrary/microchip/megaavr/peripheral/spi.h"
+#include "picolibrary/microchip/megaavr/peripheral/usart.h"
 
 /**
  * \brief Microchip megaAVR Serial Peripheral Interface (SPI) facilities.
@@ -79,6 +80,14 @@ enum class SPI_Clock_Phase : std::uint8_t {
 enum class SPI_Bit_Order : std::uint8_t {
     MSB_FIRST = 0b0 << Peripheral::SPI::SPCR::Bit::DORD, ///< MSB first.
     LSB_FIRST = 0b1 << Peripheral::SPI::SPCR::Bit::DORD, ///< LSB first.
+};
+
+/**
+ * \brief USART clock polarity.
+ */
+enum class USART_Clock_Polarity : std::uint8_t {
+    IDLE_LOW = 0b0 << Peripheral::USART::SPI_Controller::UCSRC::Bit::UCPOL, ///< Idle low.
+    IDLE_HIGH = 0b1 << Peripheral::USART::SPI_Controller::UCSRC::Bit::UCPOL, ///< Idle high.
 };
 
 } // namespace picolibrary::Microchip::megaAVR::SPI


### PR DESCRIPTION
Resolves #528 (Add Microchip megaAVR SPI USART clock polarity).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
