### PR TITLE
Add Microchip megaAVR USART based fixed configuration SPI controller echo interactive test

### DIFF
--- a/configuration/testing-interactive-atmega2560-arduino-mega-2560/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega2560-arduino-mega-2560/CMakeLists.txt
@@ -78,3 +78,4 @@ include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaa
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/gpio/push_pull_io_pin/toggle/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/i2c/controller/scan/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/spi/fixed_configuration_controller-spi/echo/CMakeLists.txt" )
+include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/spi/fixed_configuration_controller-usart/echo/CMakeLists.txt" )

--- a/configuration/testing-interactive-atmega2560-arduino-mega-2560/test/interactive/picolibrary/microchip/megaavr/spi/fixed_configuration_controller-usart/echo/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega2560-arduino-mega-2560/test/interactive/picolibrary/microchip/megaavr/spi/fixed_configuration_controller-usart/echo/CMakeLists.txt
@@ -1,0 +1,34 @@
+# picolibrary-microchip-megaavr
+#
+# Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the
+# picolibrary-microchip-megaavr contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# File: configuration/testing-interactive-atmega2560-arduino-mega-2560/test/interactive/picolibrary/microchip/megaavr/spi/fixed_configuration_controller-usart/echo/CMakeLists.txt
+# Description: picolibrary-microchip-megaavr ATmega2560 Arduino Mega 2560
+#       picolibrary::Microchip::megaAVR::SPI::Fixed_Configuration_Controller<Peripheral::USART>
+#       echo interactive test configuration.
+
+set( PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ENABLE_ECHO_INTERACTIVE_TEST                                          ON                       CACHE BOOL   "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ECHO_INTERACTIVE_TEST_CONTROLLER_USART                                "USART1"                 CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ECHO_INTERACTIVE_TEST_CONTROLLER_USART_CLOCK_GENERATOR_SCALING_FACTOR "0"                      CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ECHO_INTERACTIVE_TEST_CONTROLLER_USART_CLOCK_POLARITY                 "IDLE_LOW"               CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ECHO_INTERACTIVE_TEST_CONTROLLER_USART_CLOCK_PHASE                    "CAPTURE_IDLE_TO_ACTIVE" CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ECHO_INTERACTIVE_TEST_CONTROLLER_USART_BIT_ORDER                      "MSB_FIRST"              CACHE STRING "" FORCE )
+mark_as_advanced(
+    PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ENABLE_ECHO_INTERACTIVE_TEST
+    PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ECHO_INTERACTIVE_TEST_CONTROLLER_USART
+    PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ECHO_INTERACTIVE_TEST_CONTROLLER_USART_CLOCK_GENERATOR_SCALING_FACTOR
+    PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ECHO_INTERACTIVE_TEST_CONTROLLER_USART_CLOCK_POLARITY
+    PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ECHO_INTERACTIVE_TEST_CONTROLLER_USART_CLOCK_PHASE
+    PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ECHO_INTERACTIVE_TEST_CONTROLLER_USART_BIT_ORDER
+)

--- a/configuration/testing-interactive-atmega328p-adafruit-metro-mini/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega328p-adafruit-metro-mini/CMakeLists.txt
@@ -78,3 +78,4 @@ include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaa
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/gpio/push_pull_io_pin/toggle/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/i2c/controller/scan/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/spi/fixed_configuration_controller-spi/echo/CMakeLists.txt" )
+include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/spi/fixed_configuration_controller-usart/echo/CMakeLists.txt" )

--- a/configuration/testing-interactive-atmega328p-adafruit-metro-mini/test/interactive/picolibrary/microchip/megaavr/spi/fixed_configuration_controller-usart/echo/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega328p-adafruit-metro-mini/test/interactive/picolibrary/microchip/megaavr/spi/fixed_configuration_controller-usart/echo/CMakeLists.txt
@@ -13,11 +13,12 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# File: test/interactive/picolibrary/microchip/megaavr/spi/fixed_configuration_controller-usart/CMakeLists.txt
-# Description: picolibrary::Microchip::megaAVR::SPI::Fixed_Configuration_Controller<Peripheral::USART>
-#       interactive tests CMake rules.
+# File: configuration/testing-interactive-atmega328p-adafruit-metro-mini/test/interactive/picolibrary/microchip/megaavr/spi/fixed_configuration_controller-usart/echo/CMakeLists.txt
+# Description: picolibrary-microchip-megaavr ATmega328/P Adafruit Metro Mini
+#       picolibrary::Microchip::megaAVR::SPI::Fixed_Configuration_Controller<Peripheral::USART>
+#       echo interactive test configuration.
 
-# build the
-# picolibrary::Microchip::megaAVR::SPI::Fixed_Configuration_Controller<Peripheral::USART>
-# echo interactive test
-add_subdirectory( echo )
+set( PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ENABLE_ECHO_INTERACTIVE_TEST OFF CACHE BOOL "" FORCE )
+mark_as_advanced(
+    PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ENABLE_ECHO_INTERACTIVE_TEST
+)

--- a/configuration/testing-interactive-atmega328p-arduino-uno/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega328p-arduino-uno/CMakeLists.txt
@@ -78,3 +78,4 @@ include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaa
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/gpio/push_pull_io_pin/toggle/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/i2c/controller/scan/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/spi/fixed_configuration_controller-spi/echo/CMakeLists.txt" )
+include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/spi/fixed_configuration_controller-usart/echo/CMakeLists.txt" )

--- a/configuration/testing-interactive-atmega328p-arduino-uno/test/interactive/picolibrary/microchip/megaavr/spi/fixed_configuration_controller-usart/echo/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega328p-arduino-uno/test/interactive/picolibrary/microchip/megaavr/spi/fixed_configuration_controller-usart/echo/CMakeLists.txt
@@ -13,11 +13,12 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# File: test/interactive/picolibrary/microchip/megaavr/spi/fixed_configuration_controller-usart/CMakeLists.txt
-# Description: picolibrary::Microchip::megaAVR::SPI::Fixed_Configuration_Controller<Peripheral::USART>
-#       interactive tests CMake rules.
+# File: configuration/testing-interactive-atmega328p-arduino-uno/test/interactive/picolibrary/microchip/megaavr/spi/fixed_configuration_controller-usart/echo/CMakeLists.txt
+# Description: picolibrary-microchip-megaavr ATmega328/P Arduino Uno
+#       picolibrary::Microchip::megaAVR::SPI::Fixed_Configuration_Controller<Peripheral::USART>
+#       echo interactive test configuration.
 
-# build the
-# picolibrary::Microchip::megaAVR::SPI::Fixed_Configuration_Controller<Peripheral::USART>
-# echo interactive test
-add_subdirectory( echo )
+set( PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ENABLE_ECHO_INTERACTIVE_TEST OFF CACHE BOOL "" FORCE )
+mark_as_advanced(
+    PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ENABLE_ECHO_INTERACTIVE_TEST
+)

--- a/test/interactive/picolibrary/microchip/megaavr/spi/fixed_configuration_controller-usart/echo/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/megaavr/spi/fixed_configuration_controller-usart/echo/CMakeLists.txt
@@ -1,0 +1,85 @@
+# picolibrary-microchip-megaavr
+#
+# Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the
+# picolibrary-microchip-megaavr contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# File: test/interactive/picolibrary/microchip/megaavr/spi/fixed_configuration_controller-usart/echo/CMakeLists.txt
+# Description: picolibrary::Microchip::megaAVR::SPI::Fixed_Configuration_Controller<Peripheral::USART>
+#       echo interactive test CMake rules.
+
+# build the
+# picolibrary::Microchip::megaAVR::SPI::Fixed_Configuration_Controller<Peripheral::USART>
+# echo interactive test
+if( ${PICOLIBRARY_MICROCHIP_MEGAAVR_ENABLE_INTERACTIVE_TESTING} )
+    option(
+        PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ENABLE_ECHO_INTERACTIVE_TEST
+        "picolibrary-microchip-megaavr: enable the picolibrary::Microchip::megaAVR::SPI::Fixed_Configuration_Controller<Peripheral::USART> echo interactive test"
+        OFF
+    )
+
+    if( ${PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ENABLE_ECHO_INTERACTIVE_TEST} )
+        set(
+            PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ECHO_INTERACTIVE_TEST_CONTROLLER_USART
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr: picolibrary::Microchip::megaAVR::SPI::Fixed_Configuration_Controller<Peripheral::USART> echo interactive test controller USART"
+        )
+        set(
+            PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ECHO_INTERACTIVE_TEST_CONTROLLER_USART_CLOCK_GENERATOR_SCALING_FACTOR
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr: picolibrary::Microchip::megaAVR::SPI::Fixed_Configuration_Controller<Peripheral::USART> echo interactive test controller USART clock generator scaling factor"
+        )
+        set(
+            PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ECHO_INTERACTIVE_TEST_CONTROLLER_USART_CLOCK_POLARITY
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr: picolibrary::Microchip::megaAVR::SPI::Fixed_Configuration_Controller<Peripheral::USART> echo interactive test controller USART clock polarity"
+        )
+        set(
+            PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ECHO_INTERACTIVE_TEST_CONTROLLER_USART_CLOCK_PHASE
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr: picolibrary::Microchip::megaAVR::SPI::Fixed_Configuration_Controller<Peripheral::USART> echo interactive test controller USART clock phase"
+        )
+        set(
+            PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ECHO_INTERACTIVE_TEST_CONTROLLER_USART_BIT_ORDER
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr: picolibrary::Microchip::megaAVR::SPI::Fixed_Configuration_Controller<Peripheral::USART> echo interactive test controller USART bit order"
+        )
+
+        add_executable(
+            test-interactive-picolibrary-microchip-megaavr-spi-fixed_configuration_controller-usart-echo
+            main.cc
+        )
+        target_compile_definitions(
+            test-interactive-picolibrary-microchip-megaavr-spi-fixed_configuration_controller-usart-echo
+            PRIVATE CONTROLLER_USART=${PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ECHO_INTERACTIVE_TEST_CONTROLLER_USART}
+            PRIVATE CONTROLLER_USART_CLOCK_GENERATOR_SCALING_FACTOR=${PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ECHO_INTERACTIVE_TEST_CONTROLLER_USART_CLOCK_GENERATOR_SCALING_FACTOR}
+            PRIVATE CONTROLLER_USART_CLOCK_POLARITY=${PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ECHO_INTERACTIVE_TEST_CONTROLLER_USART_CLOCK_POLARITY}
+            PRIVATE CONTROLLER_USART_CLOCK_PHASE=${PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ECHO_INTERACTIVE_TEST_CONTROLLER_USART_CLOCK_PHASE}
+            PRIVATE CONTROLLER_USART_BIT_ORDER=${PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ECHO_INTERACTIVE_TEST_CONTROLLER_USART_BIT_ORDER}
+        )
+        target_link_libraries(
+            test-interactive-picolibrary-microchip-megaavr-spi-fixed_configuration_controller-usart-echo
+            picolibrary
+            picolibrary-microchip-megaavr
+            picolibrary-microchip-megaavr-testing-interactive-fatal_error
+        )
+        add_avrdude_programming_targets(
+            test-interactive-picolibrary-microchip-megaavr-spi-fixed_configuration_controller-usart-echo
+            "${PICOLIBRARY_MICROCHIP_MEGAAVR_AVRDUDE_RESET}"
+            CONFIGURATION_FILE "${PICOLIBRARY_MICROCHIP_MEGAAVR_AVRDUDE_CONFIGURATION_FILE}"
+            PORT               "${PICOLIBRARY_MICROCHIP_MEGAAVR_AVRDUDE_PORT}"
+            PROGRAM_FLASH      "${PICOLIBRARY_MICROCHIP_MEGAAVR_AVRDUDE_PROGRAM_FLASH}"
+            VERBOSITY          "${PICOLIBRARY_MICROCHIP_MEGAAVR_AVRDUDE_VERBOSITY}"
+            VERIFY_FLASH       "${PICOLIBRARY_MICROCHIP_MEGAAVR_AVRDUDE_VERIFY_FLASH}"
+        )
+    endif( ${PICOLIBRARY_MICROCHIP_MEGAAVR_SPI_FIXED_CONFIGURATION_CONTROLLER_USART_ENABLE_ECHO_INTERACTIVE_TEST} )
+endif( ${PICOLIBRARY_MICROCHIP_MEGAAVR_ENABLE_INTERACTIVE_TESTING} )

--- a/test/interactive/picolibrary/microchip/megaavr/spi/fixed_configuration_controller-usart/echo/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr/spi/fixed_configuration_controller-usart/echo/main.cc
@@ -1,0 +1,67 @@
+/**
+ * picolibrary-microchip-megaavr
+ *
+ * Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the
+ * picolibrary-microchip-megaavr contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Microchip::megaAVR::SPI::Fixed_Configuration_Controller<Peripheral::USART>
+ *        echo interactive test program.
+ */
+
+#include <avr-libcpp/delay>
+
+#include "picolibrary/microchip/megaavr/peripheral.h"
+#include "picolibrary/microchip/megaavr/peripheral/usart.h"
+#include "picolibrary/microchip/megaavr/spi.h"
+#include "picolibrary/testing/interactive/microchip/megaavr/log.h"
+#include "picolibrary/testing/interactive/spi.h"
+
+namespace {
+
+using ::picolibrary::Microchip::megaAVR::SPI::Fixed_Configuration_Controller;
+using ::picolibrary::Microchip::megaAVR::SPI::USART_Bit_Order;
+using ::picolibrary::Microchip::megaAVR::SPI::USART_Clock_Phase;
+using ::picolibrary::Microchip::megaAVR::SPI::USART_Clock_Polarity;
+using ::picolibrary::Testing::Interactive::Microchip::megaAVR::Log;
+using ::picolibrary::Testing::Interactive::SPI::echo;
+
+using namespace ::picolibrary::Microchip::megaAVR::Peripheral;
+
+} // namespace
+
+/**
+ * \brief Execute the
+ *        picolibrary::Microchip::megaAVR::SPI::Fixed_Configuration_Controller<Peripheral::USART>
+ *        echo interactive test.
+ *
+ * \return N/A
+ */
+int main() noexcept
+{
+    Log::initialize();
+
+    echo(
+        Log::instance(),
+        Fixed_Configuration_Controller<USART>{ CONTROLLER_USART::instance(),
+                                               CONTROLLER_USART_CLOCK_GENERATOR_SCALING_FACTOR,
+                                               USART_Clock_Polarity::CONTROLLER_USART_CLOCK_POLARITY,
+                                               USART_Clock_Phase::CONTROLLER_USART_CLOCK_PHASE,
+                                               USART_Bit_Order::CONTROLLER_USART_BIT_ORDER },
+        Fixed_Configuration_Controller<USART>::Configuration{},
+        []() { avrlibcpp::delay_ms( 100 ); } );
+
+    for ( ;; ) {} // for
+}


### PR DESCRIPTION
Resolves #550 (Add Microchip megaAVR USART based fixed configuration SPI
controller echo interactive test).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
