### PR TITLE
Add Microchip megaAVR SPI based variable configuration SPI controller interactive testing skeleton

### DIFF
--- a/test/interactive/picolibrary/microchip/megaavr/spi/variable_configuration_controller-spi/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/megaavr/spi/variable_configuration_controller-spi/CMakeLists.txt
@@ -13,20 +13,6 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# File: test/interactive/picolibrary/microchip/megaavr/spi/CMakeLists.txt
-# Description: picolibrary::Microchip::megaAVR::SPI interactive tests CMake rules.
-
-# build the
-# picolibrary::Microchip::megaAVR::SPI::Fixed_Configuration_Controller<Peripheral::SPI>
-# interactive tests
-add_subdirectory( fixed_configuration_controller-spi )
-
-# build the
-# picolibrary::Microchip::megaAVR::SPI::Fixed_Configuration_Controller<Peripheral::USART>
-# interactive tests
-add_subdirectory( fixed_configuration_controller-usart )
-
-# build the
-# picolibrary::Microchip::megaAVR::SPI::Variable_Configuration_Controller<Peripheral::SPI>
-# interactive tests
-add_subdirectory( variable_configuration_controller-spi )
+# File: test/interactive/picolibrary/microchip/megaavr/spi/variable_configuration_controller-spi/CMakeLists.txt
+# Description: picolibrary::Microchip::megaAVR::SPI::Variable_Configuration_Controller<Peripheral::SPI>
+#       interactive tests CMake rules.


### PR DESCRIPTION
Resolves #555 (Add Microchip megaAVR SPI based variable configuration
SPI controller interactive testing skeleton).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
