### PR TITLE
Add Microchip megaAVR USART based variable configuration SPI controller interactive testing skeleton

### DIFF
--- a/test/interactive/picolibrary/microchip/megaavr/spi/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/megaavr/spi/CMakeLists.txt
@@ -30,3 +30,8 @@ add_subdirectory( fixed_configuration_controller-usart )
 # picolibrary::Microchip::megaAVR::SPI::Variable_Configuration_Controller<Peripheral::SPI>
 # interactive tests
 add_subdirectory( variable_configuration_controller-spi )
+
+# build the
+# picolibrary::Microchip::megaAVR::SPI::Variable_Configuration_Controller<Peripheral::USART>
+# interactive tests
+add_subdirectory( variable_configuration_controller-usart )

--- a/test/interactive/picolibrary/microchip/megaavr/spi/variable_configuration_controller-usart/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/megaavr/spi/variable_configuration_controller-usart/CMakeLists.txt
@@ -1,0 +1,18 @@
+# picolibrary-microchip-megaavr
+#
+# Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the
+# picolibrary-microchip-megaavr contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# File: test/interactive/picolibrary/microchip/megaavr/spi/variable_configuration_controller-usart/CMakeLists.txt
+# Description: picolibrary::Microchip::megaAVR::SPI::Variable_Configuration_Controller<Peripheral::USART>
+#       interactive tests CMake rules.


### PR DESCRIPTION
Resolves #558 (Add Microchip megaAVR USART based variable configuration
SPI controller interactive testing skeleton).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
