### PR TITLE
Fix Microchip megaAVR USART based variable configuration SPI basic controller configuration default construction

### DIFF
--- a/include/picolibrary/microchip/megaavr/spi.h
+++ b/include/picolibrary/microchip/megaavr/spi.h
@@ -938,7 +938,13 @@ class Variable_Configuration_Basic_Controller<Peripheral::USART> {
         /**
          * \brief Constructor.
          */
-        constexpr Configuration() noexcept = default;
+        constexpr Configuration() noexcept :
+            Configuration{ 0,
+                           USART_Clock_Polarity::IDLE_LOW,
+                           USART_Clock_Phase::CAPTURE_IDLE_TO_ACTIVE,
+                           USART_Bit_Order::MSB_FIRST }
+        {
+        }
 
         /**
          * \brief Constructor.


### PR DESCRIPTION
Resolves #576 (Fix Microchip megaAVR USART based variable configuration
SPI basic controller configuration default construction).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
