### PR TITLE
Add Microchip MCP23008 open-drain I/O pin toggle interactive test

### DIFF
--- a/configuration/testing-interactive-atmega2560-arduino-mega-2560/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega2560-arduino-mega-2560/CMakeLists.txt
@@ -73,6 +73,7 @@ mark_as_advanced(
 # configure interactive tests
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/asynchronous_serial/unbuffered_output_stream/hello_world/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23008/internally_pulled_up_input_pin/state/CMakeLists.txt" )
+include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/asynchronous_serial/transmitter/hello_world/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/gpio/internally_pulled_up_input_pin/state/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/CMakeLists.txt" )

--- a/configuration/testing-interactive-atmega2560-arduino-mega-2560/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega2560-arduino-mega-2560/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt
@@ -1,0 +1,30 @@
+# picolibrary-microchip-megaavr
+#
+# Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the
+# picolibrary-microchip-megaavr contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# File: configuration/testing-interactive-atmega2560-arduino-mega-2560/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt
+# Description: picolibrary-microchip-megaavr ATmega2560 Arduino Mega 2560
+#       picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test
+#       configuration.
+
+set( PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST                                            ON     CACHE BOOL   "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI                                    "TWI0" CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_BIT_RATE_GENERATOR_PRESCALER_VALUE "_1"   CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_BIT_RATE_GENERATOR_SCALING_FACTOR  "12"   CACHE STRING "" FORCE )
+mark_as_advanced(
+    PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST
+    PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI
+    PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_BIT_RATE_GENERATOR_PRESCALER_VALUE
+    PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_BIT_RATE_GENERATOR_SCALING_FACTOR
+)

--- a/configuration/testing-interactive-atmega328p-adafruit-metro-mini/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega328p-adafruit-metro-mini/CMakeLists.txt
@@ -73,6 +73,7 @@ mark_as_advanced(
 # configure interactive tests
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/asynchronous_serial/unbuffered_output_stream/hello_world/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23008/internally_pulled_up_input_pin/state/CMakeLists.txt" )
+include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/asynchronous_serial/transmitter/hello_world/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/gpio/internally_pulled_up_input_pin/state/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/CMakeLists.txt" )

--- a/configuration/testing-interactive-atmega328p-adafruit-metro-mini/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega328p-adafruit-metro-mini/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt
@@ -1,0 +1,30 @@
+# picolibrary-microchip-megaavr
+#
+# Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the
+# picolibrary-microchip-megaavr contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# File: configuration/testing-interactive-atmega328p-adafruit-metro-mini/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt
+# Description: picolibrary-microchip-megaavr ATmega328/P Adafruit Metro Mini
+#       picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test
+#       configuration.
+
+set( PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST                                            ON     CACHE BOOL   "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI                                    "TWI0" CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_BIT_RATE_GENERATOR_PRESCALER_VALUE "_1"   CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_BIT_RATE_GENERATOR_SCALING_FACTOR  "12"   CACHE STRING "" FORCE )
+mark_as_advanced(
+    PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST
+    PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI
+    PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_BIT_RATE_GENERATOR_PRESCALER_VALUE
+    PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_BIT_RATE_GENERATOR_SCALING_FACTOR
+)

--- a/configuration/testing-interactive-atmega328p-arduino-uno/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega328p-arduino-uno/CMakeLists.txt
@@ -73,6 +73,7 @@ mark_as_advanced(
 # configure interactive tests
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/asynchronous_serial/unbuffered_output_stream/hello_world/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23008/internally_pulled_up_input_pin/state/CMakeLists.txt" )
+include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/asynchronous_serial/transmitter/hello_world/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/gpio/internally_pulled_up_input_pin/state/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/CMakeLists.txt" )

--- a/configuration/testing-interactive-atmega328p-arduino-uno/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega328p-arduino-uno/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt
@@ -1,0 +1,30 @@
+# picolibrary-microchip-megaavr
+#
+# Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the
+# picolibrary-microchip-megaavr contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# File: configuration/testing-interactive-atmega328p-arduino-uno/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt
+# Description: picolibrary-microchip-megaavr ATmega328/P Arduino Uno
+#       picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test
+#       configuration.
+
+set( PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST                                            ON     CACHE BOOL   "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI                                    "TWI0" CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_BIT_RATE_GENERATOR_PRESCALER_VALUE "_1"   CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_BIT_RATE_GENERATOR_SCALING_FACTOR  "12"   CACHE STRING "" FORCE )
+mark_as_advanced(
+    PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST
+    PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI
+    PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_BIT_RATE_GENERATOR_PRESCALER_VALUE
+    PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_BIT_RATE_GENERATOR_SCALING_FACTOR
+)

--- a/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/CMakeLists.txt
@@ -16,3 +16,6 @@
 # File: test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/CMakeLists.txt
 # Description: picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin interactive tests CMake
 #       rules.
+
+# build the picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test
+add_subdirectory( toggle )

--- a/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt
@@ -1,0 +1,87 @@
+# picolibrary-microchip-megaavr
+#
+# Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the
+# picolibrary-microchip-megaavr contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# File: test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt
+# Description: picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test
+#       CMake rules.
+
+# build the picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test
+if( ${PICOLIBRARY_MICROCHIP_MEGAAVR_ENABLE_INTERACTIVE_TESTING} )
+    option(
+        PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST
+        "picolibrary-microchip-megaavr: enable the picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test"
+        OFF
+    )
+
+    if( ${PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST} )
+        set(
+            PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr: picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test controller TWI"
+        )
+        set(
+            PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_BIT_RATE_GENERATOR_PRESCALER_VALUE
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr: picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test controller TWI bit rate generator prescaler value"
+        )
+        set(
+            PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_BIT_RATE_GENERATOR_SCALING_FACTOR
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr: picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test controller TWI bit rate generator scaling factor"
+        )
+        set(
+            PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_MCP23008_ADDRESS
+            "Address_Numeric{ 0b0100'000 }" CACHE STRING
+            "picolibrary-microchip-megaavr: picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test MCP23008 address"
+        )
+        set(
+            PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_MCP23008_PIN_MASK
+            "1 << 0" CACHE STRING
+            "picolibrary-microchip-megaavr: picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test MCP23008 pin mask"
+        )
+        mark_as_advanced(
+            PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_MCP23008_ADDRESS
+            PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_MCP23008_PIN_MASK
+        )
+
+        add_executable(
+            test-interactive-picolibrary-microchip-mcp23008-open_drain_io_pin-toggle
+            main.cc
+        )
+        target_compile_definitions(
+            test-interactive-picolibrary-microchip-mcp23008-open_drain_io_pin-toggle
+            PRIVATE CONTROLLER_TWI=${PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI}
+            PRIVATE CONTROLLER_TWI_BIT_RATE_GENERATOR_PRESCALER_VALUE=${PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_BIT_RATE_GENERATOR_PRESCALER_VALUE}
+            PRIVATE CONTROLLER_TWI_BIT_RATE_GENERATOR_SCALING_FACTOR=${PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_BIT_RATE_GENERATOR_SCALING_FACTOR}
+            PRIVATE MCP23008_ADDRESS=${PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_MCP23008_ADDRESS}
+            PRIVATE MCP23008_PIN_MASK=${PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_MCP23008_PIN_MASK}
+        )
+        target_link_libraries(
+            test-interactive-picolibrary-microchip-mcp23008-open_drain_io_pin-toggle
+            picolibrary
+            picolibrary-microchip-megaavr
+            picolibrary-microchip-megaavr-testing-interactive-fatal_error
+        )
+        add_avrdude_programming_targets(
+            test-interactive-picolibrary-microchip-mcp23008-open_drain_io_pin-toggle
+            "${PICOLIBRARY_MICROCHIP_MEGAAVR_AVRDUDE_RESET}"
+            CONFIGURATION_FILE "${PICOLIBRARY_MICROCHIP_MEGAAVR_AVRDUDE_CONFIGURATION_FILE}"
+            PORT               "${PICOLIBRARY_MICROCHIP_MEGAAVR_AVRDUDE_PORT}"
+            PROGRAM_FLASH      "${PICOLIBRARY_MICROCHIP_MEGAAVR_AVRDUDE_PROGRAM_FLASH}"
+            VERBOSITY          "${PICOLIBRARY_MICROCHIP_MEGAAVR_AVRDUDE_VERBOSITY}"
+            VERIFY_FLASH       "${PICOLIBRARY_MICROCHIP_MEGAAVR_AVRDUDE_VERIFY_FLASH}"
+        )
+    endif( ${PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST} )
+endif( ${PICOLIBRARY_MICROCHIP_MEGAAVR_ENABLE_INTERACTIVE_TESTING} )

--- a/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/main.cc
+++ b/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/main.cc
@@ -1,0 +1,65 @@
+/**
+ * picolibrary-microchip-megaavr
+ *
+ * Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the
+ * picolibrary-microchip-megaavr contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test
+ *        program.
+ */
+
+#include <avr-libcpp/delay>
+
+#include "picolibrary/microchip/mcp23008.h"
+#include "picolibrary/microchip/megaavr/i2c.h"
+#include "picolibrary/microchip/megaavr/peripheral.h"
+#include "picolibrary/testing/interactive/microchip/mcp23008.h"
+#include "picolibrary/testing/interactive/microchip/megaavr/log.h"
+
+namespace {
+
+using ::picolibrary::Microchip::MCP23008::Address_Numeric;
+using ::picolibrary::Microchip::MCP23008::Address_Transmitted;
+using ::picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin;
+using ::picolibrary::Microchip::megaAVR::I2C::Controller;
+using ::picolibrary::Microchip::megaAVR::I2C::TWI_Bit_Rate_Generator_Prescaler_Value;
+using ::picolibrary::Testing::Interactive::Microchip::MCP23008::toggle;
+using ::picolibrary::Testing::Interactive::Microchip::megaAVR::Log;
+
+using namespace ::picolibrary::Microchip::megaAVR::Peripheral;
+
+} // namespace
+
+/**
+ * \brief Execute the picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle
+ *        interactive test.
+ *
+ * \return N/A
+ */
+int main() noexcept
+{
+    Log::initialize();
+
+    toggle<Open_Drain_IO_Pin>(
+        Controller{ CONTROLLER_TWI::instance(),
+                    TWI_Bit_Rate_Generator_Prescaler_Value::CONTROLLER_TWI_BIT_RATE_GENERATOR_PRESCALER_VALUE,
+                    CONTROLLER_TWI_BIT_RATE_GENERATOR_SCALING_FACTOR },
+        MCP23008_ADDRESS,
+        MCP23008_PIN_MASK,
+        []() { avrlibcpp::delay_ms( 500 ); } );
+
+    for ( ;; ) {} // for
+}


### PR DESCRIPTION
Resolves #589 (Add Microchip MCP23008 open-drain I/O pin toggle
interactive test).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
