### PR TITLE
Add Microchip MCP23S08 open-drain I/O pin toggle interactive test

### DIFF
--- a/configuration/testing-interactive-atmega2560-arduino-mega-2560/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega2560-arduino-mega-2560/CMakeLists.txt
@@ -76,6 +76,7 @@ include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23008/push_pull_io_pin/toggle/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23s08/internally_pulled_up_input_pin/state/CMakeLists.txt" )
+include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23s08/open_drain_io_pin/toggle/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/asynchronous_serial/transmitter/hello_world/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/gpio/internally_pulled_up_input_pin/state/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/CMakeLists.txt" )

--- a/configuration/testing-interactive-atmega2560-arduino-mega-2560/test/interactive/picolibrary/microchip/mcp23s08/open_drain_io_pin/toggle/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega2560-arduino-mega-2560/test/interactive/picolibrary/microchip/mcp23s08/open_drain_io_pin/toggle/CMakeLists.txt
@@ -1,0 +1,36 @@
+# picolibrary-microchip-megaavr
+#
+# Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the
+# picolibrary-microchip-megaavr contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# File: configuration/testing-interactive-atmega2560-arduino-mega-2560/test/interactive/picolibrary/microchip/mcp23s08/open_drain_io_pin/toggle/CMakeLists.txt
+# Description: picolibrary-microchip-megaavr ATmega2560 Arduino Mega 2560
+#       picolibrary::Microchip::MCP23S08::Open_Drain_IO_Pin toggle interactive test
+#       configuration.
+
+set( PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST                        ON                       CACHE BOOL   "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI                "SPI0"                   CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI_CLOCK_RATE     "FOSC_2"                 CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI_CLOCK_POLARITY "IDLE_LOW"               CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI_CLOCK_PHASE    "CAPTURE_IDLE_TO_ACTIVE" CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_DEVICE_SELECTOR_PORT          "PORTB"                  CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_DEVICE_SELECTOR_MASK          "1 << 0"                 CACHE STRING "" FORCE )
+mark_as_advanced(
+    PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST
+    PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI
+    PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI_CLOCK_RATE
+    PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI_CLOCK_POLARITY
+    PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI_CLOCK_PHASE
+    PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_DEVICE_SELECTOR_PORT
+    PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_DEVICE_SELECTOR_MASK
+)

--- a/configuration/testing-interactive-atmega328p-adafruit-metro-mini/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega328p-adafruit-metro-mini/CMakeLists.txt
@@ -76,6 +76,7 @@ include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23008/push_pull_io_pin/toggle/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23s08/internally_pulled_up_input_pin/state/CMakeLists.txt" )
+include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23s08/open_drain_io_pin/toggle/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/asynchronous_serial/transmitter/hello_world/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/gpio/internally_pulled_up_input_pin/state/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/CMakeLists.txt" )

--- a/configuration/testing-interactive-atmega328p-adafruit-metro-mini/test/interactive/picolibrary/microchip/mcp23s08/open_drain_io_pin/toggle/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega328p-adafruit-metro-mini/test/interactive/picolibrary/microchip/mcp23s08/open_drain_io_pin/toggle/CMakeLists.txt
@@ -1,0 +1,36 @@
+# picolibrary-microchip-megaavr
+#
+# Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the
+# picolibrary-microchip-megaavr contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# File: configuration/testing-interactive-atmega328p-adafruit-metro-mini/test/interactive/picolibrary/microchip/mcp23s08/open_drain_io_pin/toggle/CMakeLists.txt
+# Description: picolibrary-microchip-megaavr ATmega328/P Adafruit Metro Mini
+#       picolibrary::Microchip::MCP23S08::Open_Drain_IO_Pin toggle interactive test
+#       configuration.
+
+set( PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST                        ON                       CACHE BOOL   "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI                "SPI0"                   CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI_CLOCK_RATE     "FOSC_2"                 CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI_CLOCK_POLARITY "IDLE_LOW"               CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI_CLOCK_PHASE    "CAPTURE_IDLE_TO_ACTIVE" CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_DEVICE_SELECTOR_PORT          "PORTB"                  CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_DEVICE_SELECTOR_MASK          "1 << 2"                 CACHE STRING "" FORCE )
+mark_as_advanced(
+    PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST
+    PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI
+    PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI_CLOCK_RATE
+    PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI_CLOCK_POLARITY
+    PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI_CLOCK_PHASE
+    PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_DEVICE_SELECTOR_PORT
+    PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_DEVICE_SELECTOR_MASK
+)

--- a/configuration/testing-interactive-atmega328p-arduino-uno/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega328p-arduino-uno/CMakeLists.txt
@@ -76,6 +76,7 @@ include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23008/push_pull_io_pin/toggle/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23s08/internally_pulled_up_input_pin/state/CMakeLists.txt" )
+include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23s08/open_drain_io_pin/toggle/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/asynchronous_serial/transmitter/hello_world/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/gpio/internally_pulled_up_input_pin/state/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr/gpio/open_drain_io_pin/toggle/CMakeLists.txt" )

--- a/configuration/testing-interactive-atmega328p-arduino-uno/test/interactive/picolibrary/microchip/mcp23s08/open_drain_io_pin/toggle/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega328p-arduino-uno/test/interactive/picolibrary/microchip/mcp23s08/open_drain_io_pin/toggle/CMakeLists.txt
@@ -1,0 +1,36 @@
+# picolibrary-microchip-megaavr
+#
+# Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the
+# picolibrary-microchip-megaavr contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# File: configuration/testing-interactive-atmega328p-arduino-uno/test/interactive/picolibrary/microchip/mcp23s08/open_drain_io_pin/toggle/CMakeLists.txt
+# Description: picolibrary-microchip-megaavr ATmega328/P Arduino Uno
+#       picolibrary::Microchip::MCP23S08::Open_Drain_IO_Pin toggle interactive test
+#       configuration.
+
+set( PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST                        ON                       CACHE BOOL   "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI                "SPI0"                   CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI_CLOCK_RATE     "FOSC_2"                 CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI_CLOCK_POLARITY "IDLE_LOW"               CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI_CLOCK_PHASE    "CAPTURE_IDLE_TO_ACTIVE" CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_DEVICE_SELECTOR_PORT          "PORTB"                  CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_DEVICE_SELECTOR_MASK          "1 << 2"                 CACHE STRING "" FORCE )
+mark_as_advanced(
+    PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST
+    PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI
+    PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI_CLOCK_RATE
+    PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI_CLOCK_POLARITY
+    PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI_CLOCK_PHASE
+    PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_DEVICE_SELECTOR_PORT
+    PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_DEVICE_SELECTOR_MASK
+)

--- a/test/interactive/picolibrary/microchip/mcp23s08/open_drain_io_pin/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/mcp23s08/open_drain_io_pin/CMakeLists.txt
@@ -16,3 +16,6 @@
 # File: test/interactive/picolibrary/microchip/mcp23s08/open_drain_io_pin/CMakeLists.txt
 # Description: picolibrary::Microchip::MCP23S08::Open_Drain_IO_Pin interactive tests CMake
 #       rules.
+
+# build the picolibrary::Microchip::MCP23S08::Open_Drain_IO_Pin toggle interactive test
+add_subdirectory( toggle )

--- a/test/interactive/picolibrary/microchip/mcp23s08/open_drain_io_pin/toggle/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/mcp23s08/open_drain_io_pin/toggle/CMakeLists.txt
@@ -1,0 +1,107 @@
+# picolibrary-microchip-megaavr
+#
+# Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the
+# picolibrary-microchip-megaavr contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# File: test/interactive/picolibrary/microchip/mcp23s08/open_drain_io_pin/toggle/CMakeLists.txt
+# Description: picolibrary::Microchip::MCP23S08::Open_Drain_IO_Pin toggle interactive test
+#       CMake rules.
+
+# build the picolibrary::Microchip::MCP23S08::Open_Drain_IO_Pin toggle interactive test
+if( ${PICOLIBRARY_MICROCHIP_MEGAAVR_ENABLE_INTERACTIVE_TESTING} )
+    option(
+        PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST
+        "picolibrary-microchip-megaavr: enable the picolibrary::Microchip::MCP23S08::Open_Drain_IO_Pin toggle interactive test"
+        OFF
+    )
+
+    if( ${PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST} )
+        set(
+            PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr: picolibrary::Microchip::MCP23S08::Open_Drain_IO_Pin toggle interactive test controller SPI"
+        )
+        set(
+            PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI_CLOCK_RATE
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr: picolibrary::Microchip::MCP23S08::Open_Drain_IO_Pin toggle interactive test controller SPI clock rate"
+        )
+        set(
+            PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI_CLOCK_POLARITY
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr: picolibrary::Microchip::MCP23S08::Open_Drain_IO_Pin toggle interactive test controller SPI clock polarity"
+        )
+        set(
+            PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI_CLOCK_PHASE
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr: picolibrary::Microchip::MCP23S08::Open_Drain_IO_Pin toggle interactive test controller SPI clock phase"
+        )
+
+        set(
+            PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_DEVICE_SELECTOR_PORT
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr: picolibrary::Microchip::MCP23S08::Open_Drain_IO_Pin toggle interactive test device selector PORT"
+        )
+        set(
+            PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_DEVICE_SELECTOR_MASK
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr: picolibrary::Microchip::MCP23S08::Open_Drain_IO_Pin toggle interactive test device selector mask"
+        )
+
+        set(
+            PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_MCP23S08_ADDRESS
+            "Address_Numeric{ 0b01000'00 }" CACHE STRING
+            "picolibrary-microchip-megaavr: picolibrary::Microchip::MCP23S08::Open_Drain_IO_Pin toggle interactive test MCP23S08 address"
+        )
+        set(
+            PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_MCP23S08_PIN_MASK
+            "1 << 0" CACHE STRING
+            "picolibrary-microchip-megaavr: picolibrary::Microchip::MCP23S08::Open_Drain_IO_Pin toggle interactive test MCP23S08 pin mask"
+        )
+        mark_as_advanced(
+            PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_MCP23S08_ADDRESS
+            PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_MCP23S08_PIN_MASK
+        )
+
+        add_executable(
+            test-interactive-picolibrary-microchip-mcp23s08-open_drain_io_pin-toggle
+            main.cc
+        )
+        target_compile_definitions(
+            test-interactive-picolibrary-microchip-mcp23s08-open_drain_io_pin-toggle
+            PRIVATE CONTROLLER_SPI=${PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI}
+            PRIVATE CONTROLLER_SPI_CLOCK_RATE=${PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI_CLOCK_RATE}
+            PRIVATE CONTROLLER_SPI_CLOCK_POLARITY=${PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI_CLOCK_POLARITY}
+            PRIVATE CONTROLLER_SPI_CLOCK_PHASE=${PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_SPI_CLOCK_PHASE}
+            PRIVATE DEVICE_SELECTOR_PORT=${PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_DEVICE_SELECTOR_PORT}
+            PRIVATE DEVICE_SELECTOR_MASK=${PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_DEVICE_SELECTOR_MASK}
+            PRIVATE MCP23S08_ADDRESS=${PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_MCP23S08_ADDRESS}
+            PRIVATE MCP23S08_PIN_MASK=${PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_MCP23S08_PIN_MASK}
+        )
+        target_link_libraries(
+            test-interactive-picolibrary-microchip-mcp23s08-open_drain_io_pin-toggle
+            picolibrary
+            picolibrary-microchip-megaavr
+            picolibrary-microchip-megaavr-testing-interactive-fatal_error
+        )
+        add_avrdude_programming_targets(
+            test-interactive-picolibrary-microchip-mcp23s08-open_drain_io_pin-toggle
+            "${PICOLIBRARY_MICROCHIP_MEGAAVR_AVRDUDE_RESET}"
+            CONFIGURATION_FILE "${PICOLIBRARY_MICROCHIP_MEGAAVR_AVRDUDE_CONFIGURATION_FILE}"
+            PORT               "${PICOLIBRARY_MICROCHIP_MEGAAVR_AVRDUDE_PORT}"
+            PROGRAM_FLASH      "${PICOLIBRARY_MICROCHIP_MEGAAVR_AVRDUDE_PROGRAM_FLASH}"
+            VERBOSITY          "${PICOLIBRARY_MICROCHIP_MEGAAVR_AVRDUDE_VERBOSITY}"
+            VERIFY_FLASH       "${PICOLIBRARY_MICROCHIP_MEGAAVR_AVRDUDE_VERIFY_FLASH}"
+        )
+    endif( ${PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST} )
+endif( ${PICOLIBRARY_MICROCHIP_MEGAAVR_ENABLE_INTERACTIVE_TESTING} )

--- a/test/interactive/picolibrary/microchip/mcp23s08/open_drain_io_pin/toggle/main.cc
+++ b/test/interactive/picolibrary/microchip/mcp23s08/open_drain_io_pin/toggle/main.cc
@@ -1,0 +1,80 @@
+/**
+ * picolibrary-microchip-megaavr
+ *
+ * Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the
+ * picolibrary-microchip-megaavr contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Microchip::MCP23S08::Open_Drain_IO_Pin toggle interactive test
+ *        program.
+ */
+
+#include <avr-libcpp/delay>
+
+#include "picolibrary/gpio.h"
+#include "picolibrary/microchip/mcp23s08.h"
+#include "picolibrary/microchip/megaavr/gpio.h"
+#include "picolibrary/microchip/megaavr/peripheral.h"
+#include "picolibrary/microchip/megaavr/peripheral/spi.h"
+#include "picolibrary/microchip/megaavr/spi.h"
+#include "picolibrary/spi.h"
+#include "picolibrary/testing/interactive/microchip/mcp23s08.h"
+#include "picolibrary/testing/interactive/microchip/megaavr/log.h"
+
+namespace {
+
+using ::picolibrary::GPIO::Active_Low_IO_Pin;
+using ::picolibrary::Microchip::MCP23S08::Address_Numeric;
+using ::picolibrary::Microchip::MCP23S08::Address_Transmitted;
+using ::picolibrary::Microchip::MCP23S08::Open_Drain_IO_Pin;
+using ::picolibrary::Microchip::megaAVR::GPIO::Push_Pull_IO_Pin;
+using ::picolibrary::Microchip::megaAVR::SPI::Fixed_Configuration_Controller;
+using ::picolibrary::Microchip::megaAVR::SPI::SPI_Bit_Order;
+using ::picolibrary::Microchip::megaAVR::SPI::SPI_Clock_Phase;
+using ::picolibrary::Microchip::megaAVR::SPI::SPI_Clock_Polarity;
+using ::picolibrary::Microchip::megaAVR::SPI::SPI_Clock_Rate;
+using ::picolibrary::SPI::GPIO_Output_Pin_Device_Selector;
+using ::picolibrary::Testing::Interactive::Microchip::MCP23S08::toggle;
+using ::picolibrary::Testing::Interactive::Microchip::megaAVR::Log;
+
+using namespace ::picolibrary::Microchip::megaAVR::Peripheral;
+
+} // namespace
+
+/**
+ * \brief Execute the picolibrary::Microchip::MCP23S08::Open_Drain_IO_Pin toggle
+ *        interactive test.
+ *
+ * \return N/A
+ */
+int main() noexcept
+{
+    Log::initialize();
+
+    toggle<Open_Drain_IO_Pin>(
+        Fixed_Configuration_Controller<SPI>{ CONTROLLER_SPI::instance(),
+                                             SPI_Clock_Rate::CONTROLLER_SPI_CLOCK_RATE,
+                                             SPI_Clock_Polarity::CONTROLLER_SPI_CLOCK_POLARITY,
+                                             SPI_Clock_Phase::CONTROLLER_SPI_CLOCK_PHASE,
+                                             SPI_Bit_Order::MSB_FIRST },
+        Fixed_Configuration_Controller<SPI>::Configuration{},
+        GPIO_Output_Pin_Device_Selector<Active_Low_IO_Pin<Push_Pull_IO_Pin>>{
+            DEVICE_SELECTOR_PORT::instance(), DEVICE_SELECTOR_MASK },
+        MCP23S08_ADDRESS,
+        MCP23S08_PIN_MASK,
+        []() { avrlibcpp::delay_ms( 500 ); } );
+
+    for ( ;; ) {} // for
+}


### PR DESCRIPTION
Resolves #608 (Add Microchip MCP23S08 open-drain I/O pin toggle
interactive test).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
