### PR TITLE
Replace static casts with enum underlying type conversion utility calls

### DIFF
--- a/include/picolibrary/microchip/megaavr/asynchronous_serial.h
+++ b/include/picolibrary/microchip/megaavr/asynchronous_serial.h
@@ -28,6 +28,7 @@
 
 #include "picolibrary/asynchronous_serial.h"
 #include "picolibrary/microchip/megaavr/peripheral/usart.h"
+#include "picolibrary/utility.h"
 
 /**
  * \brief Microchip megaAVR asynchronous serial facilities.
@@ -223,15 +224,14 @@ class Basic_Transmitter {
         USART_Clock_Generator_Operating_Speed usart_clock_generator_operating_speed,
         std::uint16_t usart_clock_generator_scaling_factor ) noexcept
     {
-        m_usart->normal.ucsrb = ( static_cast<std::uint8_t>( usart_data_bits ) >> USART_DATA_BITS_UCSRB_UCSZ_OFFSET )
+        m_usart->normal.ucsrb = ( to_underlying( usart_data_bits ) >> USART_DATA_BITS_UCSRB_UCSZ_OFFSET )
                                 & Peripheral::USART::Normal::UCSRB::Mask::UCSZ;
         m_usart->normal.ucsrc = Peripheral::USART::Normal::UCSRC::UMSEL_ASYNCHRONOUS_USART
-                                | ( static_cast<std::uint8_t>( usart_data_bits )
+                                | ( to_underlying( usart_data_bits )
                                     & Peripheral::USART::Normal::UCSRC::Mask::UCSZ )
-                                | static_cast<std::uint8_t>( usart_parity )
-                                | static_cast<std::uint8_t>( usart_stop_bits );
-        m_usart->normal.ucsra = static_cast<std::uint8_t>( usart_clock_generator_operating_speed );
-        m_usart->normal.ubrr = usart_clock_generator_scaling_factor;
+                                | to_underlying( usart_parity ) | to_underlying( usart_stop_bits );
+        m_usart->normal.ucsra = to_underlying( usart_clock_generator_operating_speed );
+        m_usart->normal.ubrr  = usart_clock_generator_scaling_factor;
     }
 
     /**

--- a/include/picolibrary/microchip/megaavr/i2c.h
+++ b/include/picolibrary/microchip/megaavr/i2c.h
@@ -29,6 +29,7 @@
 #include "picolibrary/i2c.h"
 #include "picolibrary/microchip/megaavr/peripheral/twi.h"
 #include "picolibrary/postcondition.h"
+#include "picolibrary/utility.h"
 
 /**
  * \brief Microchip megaAVR Inter-Integrated Circuit (I2C) facilities.
@@ -203,7 +204,7 @@ class Basic_Controller {
     {
         // #lizard forgives the length
 
-        initiate_write( address.as_unsigned_integer() | static_cast<std::uint8_t>( operation ) );
+        initiate_write( address.as_unsigned_integer() | to_underlying( operation ) );
 
         while ( not operation_complete() ) {} // while
 
@@ -322,10 +323,10 @@ class Basic_Controller {
         TWI_Bit_Rate_Generator_Prescaler_Value twi_bit_rate_generator_prescaler_value,
         std::uint8_t twi_bit_rate_generator_scaling_factor ) noexcept
     {
-        m_twi->twcr = 0;
-        m_twi->twsr = static_cast<std::uint8_t>( twi_bit_rate_generator_prescaler_value );
-        m_twi->twbr = twi_bit_rate_generator_scaling_factor;
-        m_twi->twar = 0;
+        m_twi->twcr  = 0;
+        m_twi->twsr  = to_underlying( twi_bit_rate_generator_prescaler_value );
+        m_twi->twbr  = twi_bit_rate_generator_scaling_factor;
+        m_twi->twar  = 0;
         m_twi->twamr = 0;
     }
 

--- a/include/picolibrary/microchip/megaavr/spi.h
+++ b/include/picolibrary/microchip/megaavr/spi.h
@@ -289,12 +289,10 @@ class Fixed_Configuration_Basic_Controller<Peripheral::SPI> {
         SPI_Bit_Order      spi_bit_order ) noexcept
     {
         m_spi->spcr = Peripheral::SPI::SPCR::Mask::MSTR
-                      | ( static_cast<std::uint_fast8_t>( spi_clock_rate ) >> SPI_CLOCK_RATE_SPCR_SPR_OFFSET )
-                      | static_cast<std::uint8_t>( spi_clock_polarity )
-                      | static_cast<std::uint8_t>( spi_clock_phase )
-                      | static_cast<std::uint8_t>( spi_bit_order );
-        m_spi->spsr = static_cast<std::uint_fast8_t>( spi_clock_rate )
-                      & Peripheral::SPI::SPSR::Mask::SPI2X;
+                      | ( to_underlying( spi_clock_rate ) >> SPI_CLOCK_RATE_SPCR_SPR_OFFSET )
+                      | to_underlying( spi_clock_polarity )
+                      | to_underlying( spi_clock_phase ) | to_underlying( spi_bit_order );
+        m_spi->spsr = to_underlying( spi_clock_rate ) & Peripheral::SPI::SPSR::Mask::SPI2X;
     }
 
     /**
@@ -513,9 +511,9 @@ class Fixed_Configuration_Basic_Controller<Peripheral::USART> {
     {
         m_usart->spi_host.ucsrb = 0;
         m_usart->spi_host.ucsrc = Peripheral::USART::SPI_Host::UCSRC::UMSEL_HOST_SPI
-                                  | static_cast<std::uint8_t>( usart_clock_polarity )
-                                  | static_cast<std::uint8_t>( usart_clock_phase )
-                                  | static_cast<std::uint8_t>( usart_bit_order );
+                                  | to_underlying( usart_clock_polarity )
+                                  | to_underlying( usart_clock_phase )
+                                  | to_underlying( usart_bit_order );
         m_usart->spi_host.ubrr = usart_clock_generator_scaling_factor;
     }
 
@@ -661,11 +659,11 @@ class Variable_Configuration_Basic_Controller<Peripheral::SPI> {
             SPI_Bit_Order      spi_bit_order ) noexcept :
             m_spcr{ static_cast<std::uint8_t>(
                 Peripheral::SPI::SPCR::Mask::SPE | Peripheral::SPI::SPCR::Mask::MSTR
-                | ( static_cast<std::uint_fast8_t>( spi_clock_rate ) >> SPI_CLOCK_RATE_SPCR_SPR_OFFSET )
-                | static_cast<std::uint8_t>( spi_clock_polarity ) | static_cast<std::uint8_t>( spi_clock_phase )
-                | static_cast<std::uint8_t>( spi_bit_order ) ) },
+                | ( to_underlying( spi_clock_rate ) >> SPI_CLOCK_RATE_SPCR_SPR_OFFSET )
+                | to_underlying( spi_clock_polarity ) | to_underlying( spi_clock_phase )
+                | to_underlying( spi_bit_order ) ) },
             m_spsr{ static_cast<std::uint8_t>(
-                static_cast<std::uint_fast8_t>( spi_clock_rate ) & Peripheral::SPI::SPSR::Mask::SPI2X ) }
+                to_underlying( spi_clock_rate ) & Peripheral::SPI::SPSR::Mask::SPI2X ) }
         {
         }
 
@@ -961,9 +959,8 @@ class Variable_Configuration_Basic_Controller<Peripheral::USART> {
             USART_Clock_Phase    usart_clock_phase,
             USART_Bit_Order      usart_bit_order ) noexcept :
             m_ucsrc{ static_cast<std::uint8_t>(
-                Peripheral::USART::SPI_Host::UCSRC::UMSEL_HOST_SPI
-                | static_cast<std::uint8_t>( usart_clock_polarity ) | static_cast<std::uint8_t>( usart_clock_phase )
-                | static_cast<std::uint8_t>( usart_bit_order ) ) },
+                Peripheral::USART::SPI_Host::UCSRC::UMSEL_HOST_SPI | to_underlying( usart_clock_polarity )
+                | to_underlying( usart_clock_phase ) | to_underlying( usart_bit_order ) ) },
             m_ubrr{ usart_clock_generator_scaling_factor }
         {
         }

--- a/include/picolibrary/microchip/megaavr/spi.h
+++ b/include/picolibrary/microchip/megaavr/spi.h
@@ -31,6 +31,7 @@
 #include "picolibrary/microchip/megaavr/peripheral/spi.h"
 #include "picolibrary/microchip/megaavr/peripheral/usart.h"
 #include "picolibrary/spi.h"
+#include "picolibrary/utility.h"
 
 /**
  * \brief Microchip megaAVR Serial Peripheral Interface (SPI) facilities.

--- a/include/picolibrary/testing/interactive/microchip/megaavr/log.h
+++ b/include/picolibrary/testing/interactive/microchip/megaavr/log.h
@@ -31,6 +31,7 @@
 #include "picolibrary/precondition.h"
 #include "picolibrary/result.h"
 #include "picolibrary/stream.h"
+#include "picolibrary/utility.h"
 #include "picolibrary/void.h"
 
 namespace picolibrary::Testing::Interactive::Microchip::megaAVR {
@@ -83,8 +84,8 @@ class Log : public Output_Stream {
             | ::picolibrary::Microchip::megaAVR::Peripheral::USART::Normal::UCSRC::UPM_DISABLED
             | ::picolibrary::Microchip::megaAVR::Peripheral::USART::Normal::UCSRC::USBS_1_BIT
             | ::picolibrary::Microchip::megaAVR::Peripheral::USART::Normal::UCSRC::UCSZ_8_BIT;
-        usart.normal.ucsra = static_cast<std::uint8_t>( usart_clock_generator_operating_speed );
-        usart.normal.ubrr = usart_clock_generator_scaling_factor;
+        usart.normal.ucsra = to_underlying( usart_clock_generator_operating_speed );
+        usart.normal.ubrr  = usart_clock_generator_scaling_factor;
 
         usart.normal.ucsrb |= ::picolibrary::Microchip::megaAVR::Peripheral::USART::Normal::UCSRB::Mask::TXEN;
 


### PR DESCRIPTION
Resolves #622 (Replace static casts with enum underlying type conversion
utility calls).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
