### PR TITLE
Replace return type deduction with explicit return types where reasonable

### DIFF
--- a/include/picolibrary/microchip/megaavr/asynchronous_serial.h
+++ b/include/picolibrary/microchip/megaavr/asynchronous_serial.h
@@ -155,7 +155,7 @@ class Basic_Transmitter {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Basic_Transmitter && expression ) noexcept
+    constexpr auto operator=( Basic_Transmitter && expression ) noexcept -> Basic_Transmitter &
     {
         if ( &expression != this ) {
             disable();

--- a/include/picolibrary/microchip/megaavr/gpio.h
+++ b/include/picolibrary/microchip/megaavr/gpio.h
@@ -83,7 +83,7 @@ class Pin {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Pin && expression ) noexcept
+    constexpr auto operator=( Pin && expression ) noexcept -> Pin &
     {
         if ( &expression != this ) {
             m_port = expression.m_port;
@@ -142,7 +142,7 @@ class Pin {
      * \return false if the internally pulled-up input pin's internal pull-up resistor is
      *         not disabled.
      */
-    auto pull_up_is_disabled() const noexcept
+    auto pull_up_is_disabled() const noexcept -> bool
     {
         return not pull_up_is_enabled();
     }
@@ -183,7 +183,7 @@ class Pin {
      * \return true if the pin is in the low state.
      * \return false if the pin is not in the low state.
      */
-    auto is_low() const noexcept
+    auto is_low() const noexcept -> bool
     {
         return not is_high();
     }
@@ -304,7 +304,8 @@ class Internally_Pulled_Up_Input_Pin {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Internally_Pulled_Up_Input_Pin && expression ) noexcept
+    constexpr auto operator=( Internally_Pulled_Up_Input_Pin && expression ) noexcept
+        -> Internally_Pulled_Up_Input_Pin &
     {
         if ( &expression != this ) {
             disable();
@@ -343,7 +344,7 @@ class Internally_Pulled_Up_Input_Pin {
      * \return true if the pin's internal pull-up resistor is disabled.
      * \return false if the pin's internal pull-up resistor is not disabled.
      */
-    auto pull_up_is_disabled() const noexcept
+    auto pull_up_is_disabled() const noexcept -> bool
     {
         return m_pin.pull_up_is_disabled();
     }
@@ -354,7 +355,7 @@ class Internally_Pulled_Up_Input_Pin {
      * \return true if the pin's internal pull-up resistor is enabled.
      * \return false if the pin's internal pull-up resistor is not enabled.
      */
-    auto pull_up_is_enabled() const noexcept
+    auto pull_up_is_enabled() const noexcept -> bool
     {
         return m_pin.pull_up_is_enabled();
     }
@@ -381,7 +382,7 @@ class Internally_Pulled_Up_Input_Pin {
      * \return true if the pin is in the low state.
      * \return false if the pin is not in the low state.
      */
-    auto is_low() const noexcept
+    auto is_low() const noexcept -> bool
     {
         return m_pin.is_low();
     }
@@ -392,7 +393,7 @@ class Internally_Pulled_Up_Input_Pin {
      * \return true if the pin is in the high state.
      * \return false if the pin is not in the high state.
      */
-    auto is_high() const noexcept
+    auto is_high() const noexcept -> bool
     {
         return m_pin.is_high();
     }
@@ -459,7 +460,7 @@ class Open_Drain_IO_Pin {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Open_Drain_IO_Pin && expression ) noexcept
+    constexpr auto operator=( Open_Drain_IO_Pin && expression ) noexcept -> Open_Drain_IO_Pin &
     {
         if ( &expression != this ) {
             disable();
@@ -497,7 +498,7 @@ class Open_Drain_IO_Pin {
      * \return true if the pin is in the low state.
      * \return false if the pin is not in the low state.
      */
-    auto is_low() const noexcept
+    auto is_low() const noexcept -> bool
     {
         return m_pin.is_low();
     }
@@ -508,7 +509,7 @@ class Open_Drain_IO_Pin {
      * \return true if the pin is in the high state.
      * \return false if the pin is not in the high state.
      */
-    auto is_high() const noexcept
+    auto is_high() const noexcept -> bool
     {
         return m_pin.is_high();
     }
@@ -599,7 +600,7 @@ class Push_Pull_IO_Pin {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Push_Pull_IO_Pin && expression ) noexcept
+    constexpr auto operator=( Push_Pull_IO_Pin && expression ) noexcept -> Push_Pull_IO_Pin &
     {
         if ( &expression != this ) {
             disable();
@@ -637,7 +638,7 @@ class Push_Pull_IO_Pin {
      * \return true if the pin is in the low state.
      * \return false if the pin is not in the low state.
      */
-    auto is_low() const noexcept
+    auto is_low() const noexcept -> bool
     {
         return m_pin.is_low();
     }
@@ -648,7 +649,7 @@ class Push_Pull_IO_Pin {
      * \return true if the pin is in the high state.
      * \return false if the pin is not in the high state.
      */
-    auto is_high() const noexcept
+    auto is_high() const noexcept -> bool
     {
         return m_pin.is_high();
     }

--- a/include/picolibrary/microchip/megaavr/i2c.h
+++ b/include/picolibrary/microchip/megaavr/i2c.h
@@ -102,7 +102,7 @@ class Basic_Controller {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Basic_Controller && expression ) noexcept
+    constexpr auto operator=( Basic_Controller && expression ) noexcept -> Basic_Controller &
     {
         if ( &expression != this ) {
             disable();
@@ -131,7 +131,7 @@ class Basic_Controller {
      * \return true if a bus error is present.
      * \return false if a bus error is not present.
      */
-    auto bus_error_present() const noexcept
+    auto bus_error_present() const noexcept -> bool
     {
         return controller_bus_error_present();
     }

--- a/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega2560/spi.h
+++ b/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega2560/spi.h
@@ -68,7 +68,7 @@ constexpr auto spi_port_address( std::uintptr_t spi_address ) noexcept -> std::u
  *
  * \return The SPI peripheral's pins PORT peripheral.
  */
-inline auto & spi_port( Peripheral::SPI const & spi ) noexcept
+inline auto spi_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
 {
     return *reinterpret_cast<Peripheral::PORT *>(
         spi_port_address( reinterpret_cast<std::uintptr_t>( &spi ) ) );
@@ -86,7 +86,7 @@ inline auto & spi_port( Peripheral::SPI const & spi ) noexcept
  *
  * \return The SPI peripheral's SS pin PORT peripheral address.
  */
-constexpr auto ss_port_address( std::uintptr_t spi_address ) noexcept
+constexpr auto ss_port_address( std::uintptr_t spi_address ) noexcept -> std::uintptr_t
 {
     return spi_port_address( spi_address );
 }
@@ -102,7 +102,7 @@ constexpr auto ss_port_address( std::uintptr_t spi_address ) noexcept
  *
  * \return The SPI peripheral's SS pin PORT peripheral.
  */
-inline auto & ss_port( Peripheral::SPI const & spi ) noexcept
+inline auto ss_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
 {
     return spi_port( spi );
 }
@@ -141,7 +141,7 @@ constexpr auto ss_number( std::uintptr_t spi_address ) noexcept -> std::uint_fas
  *
  * \return The SPI peripheral's SS pin number.
  */
-inline auto ss_number( Peripheral::SPI const & spi ) noexcept
+inline auto ss_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast8_t
 {
     return ss_number( reinterpret_cast<std::uintptr_t>( &spi ) );
 }
@@ -174,7 +174,7 @@ constexpr auto ss_mask( std::uintptr_t spi_address ) noexcept -> std::uint8_t
  *
  * \return The SPI peripheral's SS pin mask.
  */
-inline auto ss_mask( Peripheral::SPI const & spi ) noexcept
+inline auto ss_mask( Peripheral::SPI const & spi ) noexcept -> std::uint8_t
 {
     return ss_mask( reinterpret_cast<std::uintptr_t>( &spi ) );
 }
@@ -191,7 +191,7 @@ inline auto ss_mask( Peripheral::SPI const & spi ) noexcept
  *
  * \return The SPI peripheral's SCK pin PORT peripheral address.
  */
-constexpr auto sck_port_address( std::uintptr_t spi_address ) noexcept
+constexpr auto sck_port_address( std::uintptr_t spi_address ) noexcept -> std::uintptr_t
 {
     return spi_port_address( spi_address );
 }
@@ -207,7 +207,7 @@ constexpr auto sck_port_address( std::uintptr_t spi_address ) noexcept
  *
  * \return The SPI peripheral's SCK pin PORT peripheral.
  */
-inline auto & sck_port( Peripheral::SPI const & spi ) noexcept
+inline auto sck_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
 {
     return spi_port( spi );
 }
@@ -246,7 +246,7 @@ constexpr auto sck_number( std::uintptr_t spi_address ) noexcept -> std::uint_fa
  *
  * \return The SPI peripheral's SCK pin number.
  */
-inline auto sck_number( Peripheral::SPI const & spi ) noexcept
+inline auto sck_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast8_t
 {
     return sck_number( reinterpret_cast<std::uintptr_t>( &spi ) );
 }
@@ -279,7 +279,7 @@ constexpr auto sck_mask( std::uintptr_t spi_address ) noexcept -> std::uint8_t
  *
  * \return The SPI peripheral's SCK pin mask.
  */
-inline auto sck_mask( Peripheral::SPI const & spi ) noexcept
+inline auto sck_mask( Peripheral::SPI const & spi ) noexcept -> std::uint8_t
 {
     return sck_mask( reinterpret_cast<std::uintptr_t>( &spi ) );
 }
@@ -296,7 +296,7 @@ inline auto sck_mask( Peripheral::SPI const & spi ) noexcept
  *
  * \return The SPI peripheral's MOSI pin PORT peripheral address.
  */
-constexpr auto mosi_port_address( std::uintptr_t spi_address ) noexcept
+constexpr auto mosi_port_address( std::uintptr_t spi_address ) noexcept -> std::uintptr_t
 {
     return spi_port_address( spi_address );
 }
@@ -312,7 +312,7 @@ constexpr auto mosi_port_address( std::uintptr_t spi_address ) noexcept
  *
  * \return The SPI peripheral's MOSI pin PORT peripheral.
  */
-inline auto & mosi_port( Peripheral::SPI const & spi ) noexcept
+inline auto mosi_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
 {
     return spi_port( spi );
 }
@@ -351,7 +351,7 @@ constexpr auto mosi_number( std::uintptr_t spi_address ) noexcept -> std::uint_f
  *
  * \return The SPI peripheral's MOSI pin number.
  */
-inline auto mosi_number( Peripheral::SPI const & spi ) noexcept
+inline auto mosi_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast8_t
 {
     return mosi_number( reinterpret_cast<std::uintptr_t>( &spi ) );
 }
@@ -384,7 +384,7 @@ constexpr auto mosi_mask( std::uintptr_t spi_address ) noexcept -> std::uint8_t
  *
  * \return The SPI peripheral's MOSI pin mask.
  */
-inline auto mosi_mask( Peripheral::SPI const & spi ) noexcept
+inline auto mosi_mask( Peripheral::SPI const & spi ) noexcept -> std::uint8_t
 {
     return mosi_mask( reinterpret_cast<std::uintptr_t>( &spi ) );
 }
@@ -401,7 +401,7 @@ inline auto mosi_mask( Peripheral::SPI const & spi ) noexcept
  *
  * \return The SPI peripheral's MISO pin PORT peripheral address.
  */
-constexpr auto miso_port_address( std::uintptr_t spi_address ) noexcept
+constexpr auto miso_port_address( std::uintptr_t spi_address ) noexcept -> std::uintptr_t
 {
     return spi_port_address( spi_address );
 }
@@ -417,7 +417,7 @@ constexpr auto miso_port_address( std::uintptr_t spi_address ) noexcept
  *
  * \return The SPI peripheral's MISO pin PORT peripheral.
  */
-inline auto & miso_port( Peripheral::SPI const & spi ) noexcept
+inline auto miso_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
 {
     return spi_port( spi );
 }
@@ -456,7 +456,7 @@ constexpr auto miso_number( std::uintptr_t spi_address ) noexcept -> std::uint_f
  *
  * \return The SPI peripheral's MISO pin number.
  */
-inline auto miso_number( Peripheral::SPI const & spi ) noexcept
+inline auto miso_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast8_t
 {
     return miso_number( reinterpret_cast<std::uintptr_t>( &spi ) );
 }
@@ -489,7 +489,7 @@ constexpr auto miso_mask( std::uintptr_t spi_address ) noexcept -> std::uint8_t
  *
  * \return The SPI peripheral's MISO pin mask.
  */
-inline auto miso_mask( Peripheral::SPI const & spi ) noexcept
+inline auto miso_mask( Peripheral::SPI const & spi ) noexcept -> std::uint8_t
 {
     return miso_mask( reinterpret_cast<std::uintptr_t>( &spi ) );
 }

--- a/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega2560/twi.h
+++ b/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega2560/twi.h
@@ -68,7 +68,7 @@ constexpr auto twi_port_address( std::uintptr_t twi_address ) noexcept -> std::u
  *
  * \return The TWI peripheral's pins PORT peripheral.
  */
-inline auto & twi_port( Peripheral::TWI const & twi ) noexcept
+inline auto twi_port( Peripheral::TWI const & twi ) noexcept -> Peripheral::PORT &
 {
     return *reinterpret_cast<Peripheral::PORT *>(
         twi_port_address( reinterpret_cast<std::uintptr_t>( &twi ) ) );
@@ -86,7 +86,7 @@ inline auto & twi_port( Peripheral::TWI const & twi ) noexcept
  *
  * \return The TWI peripheral's SCL pin PORT peripheral address.
  */
-constexpr auto scl_port_address( std::uintptr_t twi_address ) noexcept
+constexpr auto scl_port_address( std::uintptr_t twi_address ) noexcept -> std::uintptr_t
 {
     return twi_port_address( twi_address );
 }
@@ -102,7 +102,7 @@ constexpr auto scl_port_address( std::uintptr_t twi_address ) noexcept
  *
  * \return The TWI peripheral's SCL pin PORT peripheral.
  */
-inline auto & scl_port( Peripheral::TWI const & twi ) noexcept
+inline auto scl_port( Peripheral::TWI const & twi ) noexcept -> Peripheral::PORT &
 {
     return twi_port( twi );
 }
@@ -141,7 +141,7 @@ constexpr auto scl_number( std::uintptr_t twi_address ) noexcept -> std::uint_fa
  *
  * \return The TWI peripheral's SCL pin number.
  */
-inline auto scl_number( Peripheral::TWI const & twi ) noexcept
+inline auto scl_number( Peripheral::TWI const & twi ) noexcept -> std::uint_fast8_t
 {
     return scl_number( reinterpret_cast<std::uintptr_t>( &twi ) );
 }
@@ -174,7 +174,7 @@ constexpr auto scl_mask( std::uintptr_t twi_address ) noexcept -> std::uint8_t
  *
  * \return The TWI peripheral's SCL pin mask.
  */
-inline auto scl_mask( Peripheral::TWI const & twi ) noexcept
+inline auto scl_mask( Peripheral::TWI const & twi ) noexcept -> std::uint8_t
 {
     return scl_mask( reinterpret_cast<std::uintptr_t>( &twi ) );
 }
@@ -191,7 +191,7 @@ inline auto scl_mask( Peripheral::TWI const & twi ) noexcept
  *
  * \return The TWI peripheral's SDA pin PORT peripheral address.
  */
-constexpr auto sda_port_address( std::uintptr_t twi_address ) noexcept
+constexpr auto sda_port_address( std::uintptr_t twi_address ) noexcept -> std::uintptr_t
 {
     return twi_port_address( twi_address );
 }
@@ -207,7 +207,7 @@ constexpr auto sda_port_address( std::uintptr_t twi_address ) noexcept
  *
  * \return The TWI peripheral's SDA pin PORT peripheral.
  */
-inline auto & sda_port( Peripheral::TWI const & twi ) noexcept
+inline auto sda_port( Peripheral::TWI const & twi ) noexcept -> Peripheral::PORT &
 {
     return twi_port( twi );
 }
@@ -246,7 +246,7 @@ constexpr auto sda_number( std::uintptr_t twi_address ) noexcept -> std::uint_fa
  *
  * \return The TWI peripheral's SDA pin number.
  */
-inline auto sda_number( Peripheral::TWI const & twi ) noexcept
+inline auto sda_number( Peripheral::TWI const & twi ) noexcept -> std::uint_fast8_t
 {
     return sda_number( reinterpret_cast<std::uintptr_t>( &twi ) );
 }
@@ -279,7 +279,7 @@ constexpr auto sda_mask( std::uintptr_t twi_address ) noexcept -> std::uint8_t
  *
  * \return The TWI peripheral's SDA pin mask.
  */
-inline auto sda_mask( Peripheral::TWI const & twi ) noexcept
+inline auto sda_mask( Peripheral::TWI const & twi ) noexcept -> std::uint8_t
 {
     return sda_mask( reinterpret_cast<std::uintptr_t>( &twi ) );
 }

--- a/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega2560/usart.h
+++ b/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega2560/usart.h
@@ -75,7 +75,7 @@ constexpr auto usart_port_address( std::uintptr_t usart_address ) noexcept -> st
  *
  * \return The USART peripheral's pins PORT peripheral.
  */
-inline auto & usart_port( Peripheral::USART const & usart ) noexcept
+inline auto usart_port( Peripheral::USART const & usart ) noexcept -> Peripheral::PORT &
 {
     return *reinterpret_cast<Peripheral::PORT *>(
         usart_port_address( reinterpret_cast<std::uintptr_t>( &usart ) ) );
@@ -93,7 +93,7 @@ inline auto & usart_port( Peripheral::USART const & usart ) noexcept
  *
  * \return The USART peripheral's XCK pin PORT peripheral address.
  */
-constexpr auto xck_port_address( std::uintptr_t usart_address ) noexcept
+constexpr auto xck_port_address( std::uintptr_t usart_address ) noexcept -> std::uintptr_t
 {
     return usart_port_address( usart_address );
 }
@@ -109,7 +109,7 @@ constexpr auto xck_port_address( std::uintptr_t usart_address ) noexcept
  *
  * \return The USART peripheral's XCK pin PORT peripheral.
  */
-inline auto & xck_port( Peripheral::USART const & usart ) noexcept
+inline auto xck_port( Peripheral::USART const & usart ) noexcept -> Peripheral::PORT &
 {
     return usart_port( usart );
 }
@@ -151,7 +151,7 @@ constexpr auto xck_number( std::uintptr_t usart_address ) noexcept -> std::uint_
  *
  * \return The USART peripheral's XCK pin number.
  */
-inline auto xck_number( Peripheral::USART const & usart ) noexcept
+inline auto xck_number( Peripheral::USART const & usart ) noexcept -> std::uint_fast8_t
 {
     return xck_number( reinterpret_cast<std::uintptr_t>( &usart ) );
 }
@@ -184,7 +184,7 @@ constexpr auto xck_mask( std::uintptr_t usart_address ) noexcept -> std::uint8_t
  *
  * \return The USART peripheral's XCK pin mask.
  */
-inline auto xck_mask( Peripheral::USART const & usart ) noexcept
+inline auto xck_mask( Peripheral::USART const & usart ) noexcept -> std::uint8_t
 {
     return xck_mask( reinterpret_cast<std::uintptr_t>( &usart ) );
 }
@@ -201,7 +201,7 @@ inline auto xck_mask( Peripheral::USART const & usart ) noexcept
  *
  * \return The USART peripheral's TXD pin PORT peripheral address.
  */
-constexpr auto txd_port_address( std::uintptr_t usart_address ) noexcept
+constexpr auto txd_port_address( std::uintptr_t usart_address ) noexcept -> std::uintptr_t
 {
     return usart_port_address( usart_address );
 }
@@ -217,7 +217,7 @@ constexpr auto txd_port_address( std::uintptr_t usart_address ) noexcept
  *
  * \return The USART peripheral's TXD pin PORT peripheral.
  */
-inline auto & txd_port( Peripheral::USART const & usart ) noexcept
+inline auto txd_port( Peripheral::USART const & usart ) noexcept -> Peripheral::PORT &
 {
     return usart_port( usart );
 }
@@ -259,7 +259,7 @@ constexpr auto txd_number( std::uintptr_t usart_address ) noexcept -> std::uint_
  *
  * \return The USART peripheral's TXD pin number.
  */
-inline auto txd_number( Peripheral::USART const & usart ) noexcept
+inline auto txd_number( Peripheral::USART const & usart ) noexcept -> std::uint_fast8_t
 {
     return txd_number( reinterpret_cast<std::uintptr_t>( &usart ) );
 }
@@ -292,7 +292,7 @@ constexpr auto txd_mask( std::uintptr_t usart_address ) noexcept -> std::uint8_t
  *
  * \return The USART peripheral's TXD pin mask.
  */
-inline auto txd_mask( Peripheral::USART const & usart ) noexcept
+inline auto txd_mask( Peripheral::USART const & usart ) noexcept -> std::uint8_t
 {
     return txd_mask( reinterpret_cast<std::uintptr_t>( &usart ) );
 }
@@ -309,7 +309,7 @@ inline auto txd_mask( Peripheral::USART const & usart ) noexcept
  *
  * \return The USART peripheral's RXD pin PORT peripheral address.
  */
-constexpr auto rxd_port_address( std::uintptr_t usart_address ) noexcept
+constexpr auto rxd_port_address( std::uintptr_t usart_address ) noexcept -> std::uintptr_t
 {
     return usart_port_address( usart_address );
 }
@@ -325,7 +325,7 @@ constexpr auto rxd_port_address( std::uintptr_t usart_address ) noexcept
  *
  * \return The USART peripheral's RXD pin PORT peripheral.
  */
-inline auto & rxd_port( Peripheral::USART const & usart ) noexcept
+inline auto rxd_port( Peripheral::USART const & usart ) noexcept -> Peripheral::PORT &
 {
     return usart_port( usart );
 }
@@ -367,7 +367,7 @@ constexpr auto rxd_number( std::uintptr_t usart_address ) noexcept -> std::uint_
  *
  * \return The USART peripheral's RXD pin number.
  */
-inline auto rxd_number( Peripheral::USART const & usart ) noexcept
+inline auto rxd_number( Peripheral::USART const & usart ) noexcept -> std::uint_fast8_t
 {
     return rxd_number( reinterpret_cast<std::uintptr_t>( &usart ) );
 }
@@ -400,7 +400,7 @@ constexpr auto rxd_mask( std::uintptr_t usart_address ) noexcept -> std::uint8_t
  *
  * \return The USART peripheral's RXD pin mask.
  */
-inline auto rxd_mask( Peripheral::USART const & usart ) noexcept
+inline auto rxd_mask( Peripheral::USART const & usart ) noexcept -> std::uint8_t
 {
     return rxd_mask( reinterpret_cast<std::uintptr_t>( &usart ) );
 }

--- a/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p/spi.h
+++ b/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p/spi.h
@@ -68,7 +68,7 @@ constexpr auto spi_port_address( std::uintptr_t spi_address ) noexcept -> std::u
  *
  * \return The SPI peripheral's pins PORT peripheral.
  */
-inline auto & spi_port( Peripheral::SPI const & spi ) noexcept
+inline auto spi_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
 {
     return *reinterpret_cast<Peripheral::PORT *>(
         spi_port_address( reinterpret_cast<std::uintptr_t>( &spi ) ) );
@@ -86,7 +86,7 @@ inline auto & spi_port( Peripheral::SPI const & spi ) noexcept
  *
  * \return The SPI peripheral's SS pin PORT peripheral address.
  */
-constexpr auto ss_port_address( std::uintptr_t spi_address ) noexcept
+constexpr auto ss_port_address( std::uintptr_t spi_address ) noexcept -> std::uintptr_t
 {
     return spi_port_address( spi_address );
 }
@@ -102,7 +102,7 @@ constexpr auto ss_port_address( std::uintptr_t spi_address ) noexcept
  *
  * \return The SPI peripheral's SS pin PORT peripheral.
  */
-inline auto & ss_port( Peripheral::SPI const & spi ) noexcept
+inline auto ss_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
 {
     return spi_port( spi );
 }
@@ -141,7 +141,7 @@ constexpr auto ss_number( std::uintptr_t spi_address ) noexcept -> std::uint_fas
  *
  * \return The SPI peripheral's SS pin number.
  */
-inline auto ss_number( Peripheral::SPI const & spi ) noexcept
+inline auto ss_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast8_t
 {
     return ss_number( reinterpret_cast<std::uintptr_t>( &spi ) );
 }
@@ -174,7 +174,7 @@ constexpr auto ss_mask( std::uintptr_t spi_address ) noexcept -> std::uint8_t
  *
  * \return The SPI peripheral's SS pin mask.
  */
-inline auto ss_mask( Peripheral::SPI const & spi ) noexcept
+inline auto ss_mask( Peripheral::SPI const & spi ) noexcept -> std::uint8_t
 {
     return ss_mask( reinterpret_cast<std::uintptr_t>( &spi ) );
 }
@@ -191,7 +191,7 @@ inline auto ss_mask( Peripheral::SPI const & spi ) noexcept
  *
  * \return The SPI peripheral's SCK pin PORT peripheral address.
  */
-constexpr auto sck_port_address( std::uintptr_t spi_address ) noexcept
+constexpr auto sck_port_address( std::uintptr_t spi_address ) noexcept -> std::uintptr_t
 {
     return spi_port_address( spi_address );
 }
@@ -207,7 +207,7 @@ constexpr auto sck_port_address( std::uintptr_t spi_address ) noexcept
  *
  * \return The SPI peripheral's SCK pin PORT peripheral.
  */
-inline auto & sck_port( Peripheral::SPI const & spi ) noexcept
+inline auto sck_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
 {
     return spi_port( spi );
 }
@@ -246,7 +246,7 @@ constexpr auto sck_number( std::uintptr_t spi_address ) noexcept -> std::uint_fa
  *
  * \return The SPI peripheral's SCK pin number.
  */
-inline auto sck_number( Peripheral::SPI const & spi ) noexcept
+inline auto sck_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast8_t
 {
     return sck_number( reinterpret_cast<std::uintptr_t>( &spi ) );
 }
@@ -279,7 +279,7 @@ constexpr auto sck_mask( std::uintptr_t spi_address ) noexcept -> std::uint8_t
  *
  * \return The SPI peripheral's SCK pin mask.
  */
-inline auto sck_mask( Peripheral::SPI const & spi ) noexcept
+inline auto sck_mask( Peripheral::SPI const & spi ) noexcept -> std::uint8_t
 {
     return sck_mask( reinterpret_cast<std::uintptr_t>( &spi ) );
 }
@@ -296,7 +296,7 @@ inline auto sck_mask( Peripheral::SPI const & spi ) noexcept
  *
  * \return The SPI peripheral's MOSI pin PORT peripheral address.
  */
-constexpr auto mosi_port_address( std::uintptr_t spi_address ) noexcept
+constexpr auto mosi_port_address( std::uintptr_t spi_address ) noexcept -> std::uintptr_t
 {
     return spi_port_address( spi_address );
 }
@@ -312,7 +312,7 @@ constexpr auto mosi_port_address( std::uintptr_t spi_address ) noexcept
  *
  * \return The SPI peripheral's MOSI pin PORT peripheral.
  */
-inline auto & mosi_port( Peripheral::SPI const & spi ) noexcept
+inline auto mosi_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
 {
     return spi_port( spi );
 }
@@ -351,7 +351,7 @@ constexpr auto mosi_number( std::uintptr_t spi_address ) noexcept -> std::uint_f
  *
  * \return The SPI peripheral's MOSI pin number.
  */
-inline auto mosi_number( Peripheral::SPI const & spi ) noexcept
+inline auto mosi_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast8_t
 {
     return mosi_number( reinterpret_cast<std::uintptr_t>( &spi ) );
 }
@@ -384,7 +384,7 @@ constexpr auto mosi_mask( std::uintptr_t spi_address ) noexcept -> std::uint8_t
  *
  * \return The SPI peripheral's MOSI pin mask.
  */
-inline auto mosi_mask( Peripheral::SPI const & spi ) noexcept
+inline auto mosi_mask( Peripheral::SPI const & spi ) noexcept -> std::uint8_t
 {
     return mosi_mask( reinterpret_cast<std::uintptr_t>( &spi ) );
 }
@@ -401,7 +401,7 @@ inline auto mosi_mask( Peripheral::SPI const & spi ) noexcept
  *
  * \return The SPI peripheral's MISO pin PORT peripheral address.
  */
-constexpr auto miso_port_address( std::uintptr_t spi_address ) noexcept
+constexpr auto miso_port_address( std::uintptr_t spi_address ) noexcept -> std::uintptr_t
 {
     return spi_port_address( spi_address );
 }
@@ -417,7 +417,7 @@ constexpr auto miso_port_address( std::uintptr_t spi_address ) noexcept
  *
  * \return The SPI peripheral's MISO pin PORT peripheral.
  */
-inline auto & miso_port( Peripheral::SPI const & spi ) noexcept
+inline auto miso_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
 {
     return spi_port( spi );
 }
@@ -456,7 +456,7 @@ constexpr auto miso_number( std::uintptr_t spi_address ) noexcept -> std::uint_f
  *
  * \return The SPI peripheral's MISO pin number.
  */
-inline auto miso_number( Peripheral::SPI const & spi ) noexcept
+inline auto miso_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast8_t
 {
     return miso_number( reinterpret_cast<std::uintptr_t>( &spi ) );
 }
@@ -489,7 +489,7 @@ constexpr auto miso_mask( std::uintptr_t spi_address ) noexcept -> std::uint8_t
  *
  * \return The SPI peripheral's MISO pin mask.
  */
-inline auto miso_mask( Peripheral::SPI const & spi ) noexcept
+inline auto miso_mask( Peripheral::SPI const & spi ) noexcept -> std::uint8_t
 {
     return miso_mask( reinterpret_cast<std::uintptr_t>( &spi ) );
 }

--- a/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p/twi.h
+++ b/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p/twi.h
@@ -68,7 +68,7 @@ constexpr auto twi_port_address( std::uintptr_t twi_address ) noexcept -> std::u
  *
  * \return The TWI peripheral's pins PORT peripheral.
  */
-inline auto & twi_port( Peripheral::TWI const & twi ) noexcept
+inline auto twi_port( Peripheral::TWI const & twi ) noexcept -> Peripheral::PORT &
 {
     return *reinterpret_cast<Peripheral::PORT *>(
         twi_port_address( reinterpret_cast<std::uintptr_t>( &twi ) ) );
@@ -86,7 +86,7 @@ inline auto & twi_port( Peripheral::TWI const & twi ) noexcept
  *
  * \return The TWI peripheral's SCL pin PORT peripheral address.
  */
-constexpr auto scl_port_address( std::uintptr_t twi_address ) noexcept
+constexpr auto scl_port_address( std::uintptr_t twi_address ) noexcept -> std::uintptr_t
 {
     return twi_port_address( twi_address );
 }
@@ -102,7 +102,7 @@ constexpr auto scl_port_address( std::uintptr_t twi_address ) noexcept
  *
  * \return The TWI peripheral's SCL pin PORT peripheral.
  */
-inline auto & scl_port( Peripheral::TWI const & twi ) noexcept
+inline auto scl_port( Peripheral::TWI const & twi ) noexcept -> Peripheral::PORT &
 {
     return twi_port( twi );
 }
@@ -141,7 +141,7 @@ constexpr auto scl_number( std::uintptr_t twi_address ) noexcept -> std::uint_fa
  *
  * \return The TWI peripheral's SCL pin number.
  */
-inline auto scl_number( Peripheral::TWI const & twi ) noexcept
+inline auto scl_number( Peripheral::TWI const & twi ) noexcept -> std::uint_fast8_t
 {
     return scl_number( reinterpret_cast<std::uintptr_t>( &twi ) );
 }
@@ -174,7 +174,7 @@ constexpr auto scl_mask( std::uintptr_t twi_address ) noexcept -> std::uint8_t
  *
  * \return The TWI peripheral's SCL pin mask.
  */
-inline auto scl_mask( Peripheral::TWI const & twi ) noexcept
+inline auto scl_mask( Peripheral::TWI const & twi ) noexcept -> std::uint8_t
 {
     return scl_mask( reinterpret_cast<std::uintptr_t>( &twi ) );
 }
@@ -191,7 +191,7 @@ inline auto scl_mask( Peripheral::TWI const & twi ) noexcept
  *
  * \return The TWI peripheral's SDA pin PORT peripheral address.
  */
-constexpr auto sda_port_address( std::uintptr_t twi_address ) noexcept
+constexpr auto sda_port_address( std::uintptr_t twi_address ) noexcept -> std::uintptr_t
 {
     return twi_port_address( twi_address );
 }
@@ -207,7 +207,7 @@ constexpr auto sda_port_address( std::uintptr_t twi_address ) noexcept
  *
  * \return The TWI peripheral's SDA pin PORT peripheral.
  */
-inline auto & sda_port( Peripheral::TWI const & twi ) noexcept
+inline auto sda_port( Peripheral::TWI const & twi ) noexcept -> Peripheral::PORT &
 {
     return twi_port( twi );
 }
@@ -246,7 +246,7 @@ constexpr auto sda_number( std::uintptr_t twi_address ) noexcept -> std::uint_fa
  *
  * \return The TWI peripheral's SDA pin number.
  */
-inline auto sda_number( Peripheral::TWI const & twi ) noexcept
+inline auto sda_number( Peripheral::TWI const & twi ) noexcept -> std::uint_fast8_t
 {
     return sda_number( reinterpret_cast<std::uintptr_t>( &twi ) );
 }
@@ -279,7 +279,7 @@ constexpr auto sda_mask( std::uintptr_t twi_address ) noexcept -> std::uint8_t
  *
  * \return The TWI peripheral's SDA pin mask.
  */
-inline auto sda_mask( Peripheral::TWI const & twi ) noexcept
+inline auto sda_mask( Peripheral::TWI const & twi ) noexcept -> std::uint8_t
 {
     return sda_mask( reinterpret_cast<std::uintptr_t>( &twi ) );
 }

--- a/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p/usart.h
+++ b/include/picolibrary/microchip/megaavr/multiplexed_signals/atmega328p/usart.h
@@ -69,7 +69,7 @@ constexpr auto usart_port_address( std::uintptr_t usart_address ) noexcept -> st
  *
  * \return The USART peripheral's pins PORT peripheral.
  */
-inline auto & usart_port( Peripheral::USART const & usart ) noexcept
+inline auto usart_port( Peripheral::USART const & usart ) noexcept -> Peripheral::PORT &
 {
     return *reinterpret_cast<Peripheral::PORT *>(
         usart_port_address( reinterpret_cast<std::uintptr_t>( &usart ) ) );
@@ -87,7 +87,7 @@ inline auto & usart_port( Peripheral::USART const & usart ) noexcept
  *
  * \return The USART peripheral's XCK pin PORT peripheral address.
  */
-constexpr auto xck_port_address( std::uintptr_t usart_address ) noexcept
+constexpr auto xck_port_address( std::uintptr_t usart_address ) noexcept -> std::uintptr_t
 {
     return usart_port_address( usart_address );
 }
@@ -103,7 +103,7 @@ constexpr auto xck_port_address( std::uintptr_t usart_address ) noexcept
  *
  * \return The USART peripheral's XCK pin PORT peripheral.
  */
-inline auto & xck_port( Peripheral::USART const & usart ) noexcept
+inline auto xck_port( Peripheral::USART const & usart ) noexcept -> Peripheral::PORT &
 {
     return usart_port( usart );
 }
@@ -142,7 +142,7 @@ constexpr auto xck_number( std::uintptr_t usart_address ) noexcept -> std::uint_
  *
  * \return The USART peripheral's XCK pin number.
  */
-inline auto xck_number( Peripheral::USART const & usart ) noexcept
+inline auto xck_number( Peripheral::USART const & usart ) noexcept -> std::uint_fast8_t
 {
     return xck_number( reinterpret_cast<std::uintptr_t>( &usart ) );
 }
@@ -175,7 +175,7 @@ constexpr auto xck_mask( std::uintptr_t usart_address ) noexcept -> std::uint8_t
  *
  * \return The USART peripheral's XCK pin mask.
  */
-inline auto xck_mask( Peripheral::USART const & usart ) noexcept
+inline auto xck_mask( Peripheral::USART const & usart ) noexcept -> std::uint8_t
 {
     return xck_mask( reinterpret_cast<std::uintptr_t>( &usart ) );
 }
@@ -192,7 +192,7 @@ inline auto xck_mask( Peripheral::USART const & usart ) noexcept
  *
  * \return The USART peripheral's TXD pin PORT peripheral address.
  */
-constexpr auto txd_port_address( std::uintptr_t usart_address ) noexcept
+constexpr auto txd_port_address( std::uintptr_t usart_address ) noexcept -> std::uintptr_t
 {
     return usart_port_address( usart_address );
 }
@@ -208,7 +208,7 @@ constexpr auto txd_port_address( std::uintptr_t usart_address ) noexcept
  *
  * \return The USART peripheral's TXD pin PORT peripheral.
  */
-inline auto & txd_port( Peripheral::USART const & usart ) noexcept
+inline auto txd_port( Peripheral::USART const & usart ) noexcept -> Peripheral::PORT &
 {
     return usart_port( usart );
 }
@@ -247,7 +247,7 @@ constexpr auto txd_number( std::uintptr_t usart_address ) noexcept -> std::uint_
  *
  * \return The USART peripheral's TXD pin number.
  */
-inline auto txd_number( Peripheral::USART const & usart ) noexcept
+inline auto txd_number( Peripheral::USART const & usart ) noexcept -> std::uint_fast8_t
 {
     return txd_number( reinterpret_cast<std::uintptr_t>( &usart ) );
 }
@@ -280,7 +280,7 @@ constexpr auto txd_mask( std::uintptr_t usart_address ) noexcept -> std::uint8_t
  *
  * \return The USART peripheral's TXD pin mask.
  */
-inline auto txd_mask( Peripheral::USART const & usart ) noexcept
+inline auto txd_mask( Peripheral::USART const & usart ) noexcept -> std::uint8_t
 {
     return txd_mask( reinterpret_cast<std::uintptr_t>( &usart ) );
 }
@@ -297,7 +297,7 @@ inline auto txd_mask( Peripheral::USART const & usart ) noexcept
  *
  * \return The USART peripheral's RXD pin PORT peripheral address.
  */
-constexpr auto rxd_port_address( std::uintptr_t usart_address ) noexcept
+constexpr auto rxd_port_address( std::uintptr_t usart_address ) noexcept -> std::uintptr_t
 {
     return usart_port_address( usart_address );
 }
@@ -313,7 +313,7 @@ constexpr auto rxd_port_address( std::uintptr_t usart_address ) noexcept
  *
  * \return The USART peripheral's RXD pin PORT peripheral.
  */
-inline auto & rxd_port( Peripheral::USART const & usart ) noexcept
+inline auto rxd_port( Peripheral::USART const & usart ) noexcept -> Peripheral::PORT &
 {
     return usart_port( usart );
 }
@@ -352,7 +352,7 @@ constexpr auto rxd_number( std::uintptr_t usart_address ) noexcept -> std::uint_
  *
  * \return The USART peripheral's RXD pin number.
  */
-inline auto rxd_number( Peripheral::USART const & usart ) noexcept
+inline auto rxd_number( Peripheral::USART const & usart ) noexcept -> std::uint_fast8_t
 {
     return rxd_number( reinterpret_cast<std::uintptr_t>( &usart ) );
 }
@@ -385,7 +385,7 @@ constexpr auto rxd_mask( std::uintptr_t usart_address ) noexcept -> std::uint8_t
  *
  * \return The USART peripheral's RXD pin mask.
  */
-inline auto rxd_mask( Peripheral::USART const & usart ) noexcept
+inline auto rxd_mask( Peripheral::USART const & usart ) noexcept -> std::uint8_t
 {
     return rxd_mask( reinterpret_cast<std::uintptr_t>( &usart ) );
 }

--- a/include/picolibrary/microchip/megaavr/peripheral/instance.h
+++ b/include/picolibrary/microchip/megaavr/peripheral/instance.h
@@ -51,7 +51,7 @@ class Instance {
      *
      * \return The peripheral instance.
      */
-    static auto & instance() noexcept
+    static auto instance() noexcept -> Type &
     {
         return *reinterpret_cast<Type *>( ADDRESS );
     }

--- a/include/picolibrary/microchip/megaavr/register.h
+++ b/include/picolibrary/microchip/megaavr/register.h
@@ -71,7 +71,7 @@ class Register {
      *
      * \return The assigned to object.
      */
-    auto & operator=( Type expression ) noexcept
+    auto operator=( Type expression ) noexcept -> Register &
     {
         m_register = expression;
 
@@ -85,7 +85,7 @@ class Register {
      *
      * \return The assigned to object.
      */
-    auto & operator&=( Type expression ) noexcept
+    auto operator&=( Type expression ) noexcept -> Register &
     {
         m_register &= expression;
 
@@ -99,7 +99,7 @@ class Register {
      *
      * \return The assigned to object.
      */
-    auto & operator|=( Type expression ) noexcept
+    auto operator|=( Type expression ) noexcept -> Register &
     {
         m_register |= expression;
 
@@ -113,7 +113,7 @@ class Register {
      *
      * \return The assigned to object.
      */
-    auto & operator^=( Type expression ) noexcept
+    auto operator^=( Type expression ) noexcept -> Register &
     {
         m_register ^= expression;
 

--- a/include/picolibrary/microchip/megaavr/spi.h
+++ b/include/picolibrary/microchip/megaavr/spi.h
@@ -1022,7 +1022,7 @@ class Variable_Configuration_Basic_Controller<Peripheral::USART> {
          *
          * \return The configuration's UBRR register value.
          */
-        constexpr auto ubrr() const noexcept -> std::uint8_t
+        constexpr auto ubrr() const noexcept -> std::uint16_t
         {
             return m_ubrr;
         }

--- a/include/picolibrary/microchip/megaavr/spi.h
+++ b/include/picolibrary/microchip/megaavr/spi.h
@@ -200,7 +200,8 @@ class Fixed_Configuration_Basic_Controller<Peripheral::SPI> {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Fixed_Configuration_Basic_Controller && expression ) noexcept
+    constexpr auto operator=( Fixed_Configuration_Basic_Controller && expression ) noexcept
+        -> Fixed_Configuration_Basic_Controller &
     {
         if ( &expression != this ) {
             disable();
@@ -245,7 +246,7 @@ class Fixed_Configuration_Basic_Controller<Peripheral::SPI> {
      *
      * \return The data received from the device.
      */
-    auto exchange( std::uint8_t data ) noexcept
+    auto exchange( std::uint8_t data ) noexcept -> std::uint8_t
     {
         initiate_exchange( data );
 
@@ -414,7 +415,8 @@ class Fixed_Configuration_Basic_Controller<Peripheral::USART> {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Fixed_Configuration_Basic_Controller && expression ) noexcept
+    constexpr auto operator=( Fixed_Configuration_Basic_Controller && expression ) noexcept
+        -> Fixed_Configuration_Basic_Controller &
     {
         if ( &expression != this ) {
             disable();
@@ -463,7 +465,7 @@ class Fixed_Configuration_Basic_Controller<Peripheral::USART> {
      *
      * \return The data received from the device.
      */
-    auto exchange( std::uint8_t data ) noexcept
+    auto exchange( std::uint8_t data ) noexcept -> std::uint8_t
     {
         while ( not transmit_buffer_is_empty() ) {} // while
 
@@ -711,7 +713,7 @@ class Variable_Configuration_Basic_Controller<Peripheral::SPI> {
          *
          * \return The configuration's SPCR register value.
          */
-        constexpr auto spcr() const noexcept
+        constexpr auto spcr() const noexcept -> std::uint8_t
         {
             return m_spcr;
         }
@@ -721,7 +723,7 @@ class Variable_Configuration_Basic_Controller<Peripheral::SPI> {
          *
          * \return The configuration's SPSR register value.
          */
-        constexpr auto spsr() const noexcept
+        constexpr auto spsr() const noexcept -> std::uint8_t
         {
             return m_spsr;
         }
@@ -786,7 +788,8 @@ class Variable_Configuration_Basic_Controller<Peripheral::SPI> {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Variable_Configuration_Basic_Controller && expression ) noexcept
+    constexpr auto operator=( Variable_Configuration_Basic_Controller && expression ) noexcept
+        -> Variable_Configuration_Basic_Controller &
     {
         if ( &expression != this ) {
             disable();
@@ -831,7 +834,7 @@ class Variable_Configuration_Basic_Controller<Peripheral::SPI> {
      *
      * \return The data received from the device.
      */
-    auto exchange( std::uint8_t data ) noexcept
+    auto exchange( std::uint8_t data ) noexcept -> std::uint8_t
     {
         initiate_exchange( data );
 
@@ -1009,7 +1012,7 @@ class Variable_Configuration_Basic_Controller<Peripheral::USART> {
          *
          * \return The configuration's UCSRC register value.
          */
-        constexpr auto ucsrc() const noexcept
+        constexpr auto ucsrc() const noexcept -> std::uint8_t
         {
             return m_ucsrc;
         }
@@ -1019,7 +1022,7 @@ class Variable_Configuration_Basic_Controller<Peripheral::USART> {
          *
          * \return The configuration's UBRR register value.
          */
-        constexpr auto ubrr() const noexcept
+        constexpr auto ubrr() const noexcept -> std::uint8_t
         {
             return m_ubrr;
         }
@@ -1083,7 +1086,8 @@ class Variable_Configuration_Basic_Controller<Peripheral::USART> {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Variable_Configuration_Basic_Controller && expression ) noexcept
+    constexpr auto operator=( Variable_Configuration_Basic_Controller && expression ) noexcept
+        -> Variable_Configuration_Basic_Controller &
     {
         if ( &expression != this ) {
             disable();
@@ -1128,7 +1132,7 @@ class Variable_Configuration_Basic_Controller<Peripheral::USART> {
      *
      * \return The data received from the device.
      */
-    auto exchange( std::uint8_t data ) noexcept
+    auto exchange( std::uint8_t data ) noexcept -> std::uint8_t
     {
         while ( not transmit_buffer_is_empty() ) {} // while
 

--- a/include/picolibrary/testing/interactive/microchip/megaavr/log.h
+++ b/include/picolibrary/testing/interactive/microchip/megaavr/log.h
@@ -134,7 +134,7 @@ class Log : public Output_Stream {
      *
      * \return The log instance.
      */
-    static auto & instance() noexcept
+    static auto instance() noexcept -> Log &
     {
         expect( is_initialized(), Generic_Error::LOGIC_ERROR );
 


### PR DESCRIPTION
Resolves #623 (Replace return type deduction with explicit return types
where reasonable).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
