### PR TITLE
Add asynchronous serial reliable unbuffered output stream interactive testing skeleton

### DIFF
--- a/test/interactive/picolibrary/asynchronous_serial/reliable_unbuffered_output_stream/CMakeLists.txt
+++ b/test/interactive/picolibrary/asynchronous_serial/reliable_unbuffered_output_stream/CMakeLists.txt
@@ -13,11 +13,5 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# Description: picolibrary::Asynchronous_Serial interactive tests CMake rules.
-
-# build the picolibrary::Asynchronous_Serial::Reliable_Unbuffered_Output_Stream
-# interactive tests
-add_subdirectory( reliable_unbuffered_output_stream )
-
-# build the picolibrary::Asynchronous_Serial::Unbuffered_Output_Stream interactive tests
-add_subdirectory( unbuffered_output_stream )
+# Description: picolibrary::Asynchronous_Serial::Reliable_Unbuffered_Output_Stream
+#       interactive tests CMake rules.


### PR DESCRIPTION
Resolves #649 (Add asynchronous serial reliable unbuffered output stream
interactive testing skeleton).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
