### PR TITLE
Add WIZnet W5500 IP network stack interactive testing skeleton

### DIFF
--- a/test/interactive/picolibrary/wiznet/w5500/ip/network_stack/CMakeLists.txt
+++ b/test/interactive/picolibrary/wiznet/w5500/ip/network_stack/CMakeLists.txt
@@ -13,7 +13,5 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# Description: picolibrary::WIZnet::W5500::IP interactive tests CMake rules.
-
-# build the picolibrary::WIZnet::W5500::IP::Network_Stack interactive tests
-add_subdirectory( network_stack )
+# Description: picolibrary::WIZnet::W5500::IP::Network_Stack interactive tests CMake
+#       rules.


### PR DESCRIPTION
Resolves #657 (Add WIZnet W5500 IP network stack interactive testing
skeleton).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
