### PR TITLE
Add null-terminated ROM string distance getter

### DIFF
--- a/include/picolibrary/hil/rom.h
+++ b/include/picolibrary/hil/rom.h
@@ -359,6 +359,21 @@ constexpr auto operator-( std::ptrdiff_t n, String string ) noexcept -> String
 }
 
 /**
+ * \brief Get the distance between two pointers.
+ *
+ * \relatedalso picolibrary::ROM::String
+ *
+ * \param[in] lhs The left hand side of the operation.
+ * \param[in] rhs The right hand side of the operation.
+ *
+ * \return The distance between the two pointers.
+ */
+constexpr auto operator-( String lhs, String rhs ) noexcept -> std::ptrdiff_t
+{
+    return lhs.string() - rhs.string();
+}
+
+/**
  * \brief Create a string literal stored in ROM.
  *
  * \relatedalso picolibrary::ROM::String


### PR DESCRIPTION
Resolves #730 (Add null-terminated ROM string distance getter).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
