### PR TITLE
Add null-terminated ROM string transmission to Microchip megaAVR interactive testing log buffer

### DIFF
--- a/include/picolibrary/testing/interactive/microchip/megaavr/log.h
+++ b/include/picolibrary/testing/interactive/microchip/megaavr/log.h
@@ -207,6 +207,16 @@ class Log : public Reliable_Output_Stream {
         }
 
         /**
+         * \brief Transmit a null-terminated ROM string.
+         *
+         * \param[in] string The null-terminated ROM string to transmit.
+         */
+        void put( ROM::String string ) noexcept override final
+        {
+            transmit( string );
+        }
+
+        /**
          * \brief Transmit an unsigned byte.
          *
          * \param[in] value The unsigned byte to transmit.


### PR DESCRIPTION
Resolves #733 (Add null-terminated ROM string transmission to Microchip megaAVR interactive testing log buffer).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
