### PR TITLE
Improve Microchip megaAVR asynchronous serial basic transmitter constructor parameter documentation wording

### DIFF
--- a/include/picolibrary/microchip/megaavr/asynchronous_serial.h
+++ b/include/picolibrary/microchip/megaavr/asynchronous_serial.h
@@ -105,7 +105,7 @@ class Basic_Transmitter {
     /**
      * \brief Constructor.
      *
-     * \param[in] usart The USART to be used by the transmitter.
+     * \param[in] usart The USART peripheral to be used by the transmitter.
      * \param[in] usart_data_bits The desired USART data bits configuration.
      * \param[in] usart_parity The desired USART parity configuration.
      * \param[in] usart_stop_bits The desired USART stop bits configuration.


### PR DESCRIPTION
Resolves #786 (Improve Microchip megaAVR asynchronous serial basic transmitter constructor parameter documentation wording).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
