### PR TITLE
Add WIZnet W5500 UDP over IP socket interactive testing skeleton

### DIFF
--- a/test/interactive/picolibrary/wiznet/w5500/ip/udp/socket/CMakeLists.txt
+++ b/test/interactive/picolibrary/wiznet/w5500/ip/udp/socket/CMakeLists.txt
@@ -13,7 +13,4 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# Description: picolibrary::WIZnet::W5500::IP::UDP interactive tests CMake rules.
-
-# picolibrary::WIZnet::W5500::IP::UDP::Socket interactive tests
-add_subdirectory( socket )
+# Description: picolibrary::WIZnet::W5500::IP::UDP::Socket interactive tests CMake rules.


### PR DESCRIPTION
Resolves #837 (Add WIZnet W5500 UDP over IP socket interactive testing skeleton).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
